### PR TITLE
Added support for DMP output

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -278,7 +278,7 @@ var JsDiff = (function() {
         }
       }
       return ret.join("");
-    }
+    },
     
     convertChangesToDMP: function(changes){
       var ret = [], change;

--- a/test/diffTest.js
+++ b/test/diffTest.js
@@ -614,3 +614,12 @@ exports['Patch'] = function() {
     diffResult,
     "Patch same diffResult Value");
 };
+
+exports['convertToDMP'] = function() {
+    diffResult = diff.diffWords("New Value  ", "New  ValueMoreData ");
+
+    assert.deepEqual(
+        [[0,'New  '],[1,'ValueMoreData'],[-1,'Value'],[0,' ']],
+        diff.convertChangesToDMP(diffResult),
+        "DMP conversion of diffResult");
+};


### PR DESCRIPTION
Support for [`diff_match_patch`style](http://code.google.com/p/google-diff-match-patch/wiki/API) output. This means that other utilities expecting this semi-standard format can be employed.
