### PR TITLE
adding an `.npmignore` file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+test/
+.jshintrc
+.travis.yml
+index.html
+style.css


### PR DESCRIPTION
should slightly help speed up `npm i` time, and is generally a good practice
