### PR TITLE
Added variant of WordDiff that doesn't ignore whitespace differences

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -153,7 +153,8 @@ var JsDiff = (function() {
   var CharDiff = new Diff();
 
   var WordDiff = new Diff(true);
-  WordDiff.tokenize = function(value) {
+  var WordWithSpaceDiff = new Diff();
+  WordDiff.tokenize = WordWithSpaceDiff.tokenize = function(value) {
     return removeEmpty(value.split(/(\s+|\b)/));
   };
 
@@ -172,6 +173,7 @@ var JsDiff = (function() {
 
     diffChars: function(oldStr, newStr) { return CharDiff.diff(oldStr, newStr); },
     diffWords: function(oldStr, newStr) { return WordDiff.diff(oldStr, newStr); },
+    diffWordsWithSpace: function(oldStr, newStr) { return WordWithSpaceDiff.diff(oldStr, newStr); },
     diffLines: function(oldStr, newStr) { return LineDiff.diff(oldStr, newStr); },
 
     diffCss: function(oldStr, newStr) { return CssDiff.diff(oldStr, newStr); },


### PR DESCRIPTION
Right now mocha uses the `DiffWords` algorithm to back its string diffs feature: http://tjholowaychuk.com/post/18574009869/mocha-string-diffs

However, the fact that `DiffWords` ignores whitespace differences makes it extremely hard to debug problems with differences in eg. line endings:

``` javascript
require('diff').diffWords('foo\nbar', 'foo\r\nbar'); 
[ { value: 'foo\r\nbar',
    added: undefined,
    removed: undefined } ]
```

... because that makes the test framework render the text without any added/removed text highlighted.

`DiffChar` doesn't suffer from this problem, but for long texts it's very hard to make sense of a char-based diff, so there's a use case for a mode that diffs word-by-word, but doesn't ignore whitespace differences. Turns out that was extremely easy to achieve, so this PR gives you:

``` javascript
> require('diff').diffWordsWithSpace('foo\nbar', 'foo\r\nbar');
[ { value: 'foo',
    added: undefined,
    removed: undefined },
  { value: '\r\n',
    added: true,
    removed: undefined },
  { value: '\n',
    added: undefined,
    removed: true },
  { value: 'bar',
    added: undefined,
    removed: undefined } ]
```

Seems like vows has the same issue: https://github.com/cloudhead/vows/issues/281
