### PR TITLE
Handle windows newlines on non windows machines.

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -165,7 +165,20 @@ var JsDiff = (function() {
 
   var LineDiff = new Diff();
   LineDiff.tokenize = function(value) {
-    return value.split(/^/m);
+    var retLines = [];
+    var lines = value.split(/^/m);
+
+    for(var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      var lastLine = lines[i - 1];
+
+      if(line == '\n' && lastLine && lastLine.indexOf('\r') == lastLine.length - 1)
+        retLines[retLines.length - 1] += '\n';
+      else if(line)
+        retLines.push(line);
+    }
+
+    return retLines;
   };
 
   return {

--- a/test/diffTest.js
+++ b/test/diffTest.js
@@ -103,6 +103,13 @@ describe('#diffLines', function() {
       'line\nvalue\nline');
     diff.convertChangesToXML(diffResult).should.equal('line\n<ins>value\n</ins><del>value \n</del>line');
   });
+
+  it('should handle windows line endings', function() {
+    var diffResult = diff.diffLines(
+      'line\r\nold value \r\nline',
+      'line\r\nnew value\r\nline');
+    diff.convertChangesToXML(diffResult).should.equal('line\r\n<ins>new value\r\n</ins><del>old value \r\n</del>line');
+  });
 });
 
 describe('convertToDMP', function() {


### PR DESCRIPTION
`value.split(/^/m)` splits `some\r\ntext` into 3 different elements:

```
['some\r', '\n', 'text']
```

Not good for diffing! So this makes it:

```
['some\r\n', 'text']
```
