### PR TITLE
Don't rely on Array.prototype.map

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -25,9 +25,7 @@
       var other = new Array(arr.length);
 
       for (var i = 0, n = arr.length; i < n; i++) {
-        if (i in arr) {
-          other[i] = mapper.call(that, arr[i], i, arr);
-        }
+        other[i] = mapper.call(that, arr[i], i, arr);
       }
       return other;
     }


### PR DESCRIPTION
Seems like this is the only thing that makes https://github.com/visionmedia/mocha not work in older browsers.
