### PR TITLE
add condition to export node.js

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -530,9 +530,11 @@
 
   /*istanbul ignore next */
   if (typeof exports !== 'undefined') {
+    /* node.js export */
     if (typeof module !== 'undefined' && module.exports) {
       exports = module.exports = JsDiff;
     }
+    exports.JsDiff = JsDiff;
   }
   else if (typeof define === 'function') {
     /*global define */


### PR DESCRIPTION
I found a bug when I use JsDiff with QUnit, JsDiff object is undefined.
this patch make possible to define JsDiff object when 'module' function is defined in browser environment.
