### PR TITLE
change condition of using node export system.

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -529,12 +529,8 @@
   })();
 
   /*istanbul ignore next */
-  if (typeof exports !== 'undefined') {
-    /* node.js export */
-    if (typeof module !== 'undefined' && module.exports) {
-      exports = module.exports = JsDiff;
-    }
-    exports.JsDiff = JsDiff;
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = JsDiff;
   }
   else if (typeof define === 'function') {
     /*global define */


### PR DESCRIPTION
The original condition of using node export system causes error when used with QUnit.

QUnit's 'module' Function is defined globaly. 
So current export logic is malfunctioning.

I change that logic more precise.
