### PR TITLE
Fix AMD module loading

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -532,7 +532,7 @@
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = JsDiff;
   }
-  else if (typeof define === 'function') {
+  else if (typeof define === 'function' && define.amd) {
     /*global define */
     define([], function() { return JsDiff; });
   }


### PR DESCRIPTION
Hi,

I am using AMD with an ember-cli app and it seems that JsDiff doesn't get loaded as a module unless you do a `define.amd` when you test for the `define` function.

I really don't know if this is correct pattern to do this but I've seen this behaviour in some other libraries and know it's loading correctly.

Cheers,