### PR TITLE
Two files patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,19 @@ or
 
     Returns a list of change objects (See below).
 
-* `JsDiff.createPatch(fileName, oldStr, newStr, oldHeader, newHeader)` - creates a unified diff patch.
+* `JsDiff.createTwoFilesPatch(oldFileName, newFileName, oldStr, newStr, oldHeader, newHeader)` - creates a unified diff patch.
 
     Parameters:
-    * `fileName` : String to be output in the filename sections of the patch
+    * `oldFileName` : String to be output in the filename section of the patch for the removals
+    * `newFileName` : String to be output in the filename section of the patch for the additions
     * `oldStr` : Original string value
     * `newStr` : New string value
     * `oldHeader` : Additional information to include in the old file header
     * `newHeader` : Additional information to include in thew new file header
+
+* `JsDiff.createPatch(fileName, oldStr, newStr, oldHeader, newHeader)` - creates a unified diff patch.
+
+    Just like JsDiff.createTwoFilesPatch, but with oldFileName being equal to newFileName.
 
 * `JsDiff.applyPatch(oldStr, diffStr)` - applies a unified diff patch.
 

--- a/diff.js
+++ b/diff.js
@@ -370,13 +370,15 @@
         );
       },
 
-      createPatch: function(fileName, oldStr, newStr, oldHeader, newHeader) {
+      createTwoFilesPatch: function(oldFileName, newFileName, oldStr, newStr, oldHeader, newHeader) {
         var ret = [];
 
-        ret.push('Index: ' + fileName);
+        if (oldFileName == newFileName) {
+          ret.push('Index: ' + oldFileName);
+	}
         ret.push('===================================================================');
-        ret.push('--- ' + fileName + (typeof oldHeader === 'undefined' ? '' : '\t' + oldHeader));
-        ret.push('+++ ' + fileName + (typeof newHeader === 'undefined' ? '' : '\t' + newHeader));
+        ret.push('--- ' + oldFileName + (typeof oldHeader === 'undefined' ? '' : '\t' + oldHeader));
+        ret.push('+++ ' + newFileName + (typeof newHeader === 'undefined' ? '' : '\t' + newHeader));
 
         var diff = LineDiff.diff(oldStr, newStr);
         if (!diff[diff.length-1].value) {
@@ -453,6 +455,10 @@
         }
 
         return ret.join('\n') + '\n';
+      },
+
+      createPatch: function(fileName, oldStr, newStr, oldHeader, newHeader) {
+        return JsDiff.createTwoFilesPatch(fileName, fileName, oldStr, newStr, oldHeader, newHeader);
       },
 
       applyPatch: function(oldStr, uniDiff) {


### PR DESCRIPTION
When comparing strings that represent different versions, say 0.1.0/README and 0.1.1/README, it is nicer to include that metadata in the patch.
The proposed changes introduce createTwoFilesPatch, which allows it to take the old and new file names. createPatch calls the new function.