### PR TITLE
fix: error throwing when apply patch to empty string

### DIFF
--- a/src/patch/apply.js
+++ b/src/patch/apply.js
@@ -53,7 +53,7 @@ export function applyPatch(source, uniDiff, options = {}) {
         lines.splice(toPos, 0, content);
         toPos++;
       } else if (operation === '\\') {
-        let previousOperation = hunk.lines[j - 1][0];
+        let previousOperation = hunk.lines[j - 1] ? hunk.lines[j - 1][0] : null;
         if (previousOperation === '+') {
           removeEOFNL = true;
         } else if (previousOperation === '-') {

--- a/test/patch/apply.js
+++ b/test/patch/apply.js
@@ -413,6 +413,23 @@ describe('patch/apply', function() {
       const diffed = createPatch('test', oldtext, newtext);
       expect(applyPatch(oldtext, diffed)).to.equal(newtext);
     });
+
+    it('handle empty text', function() {
+      const oldtext = '';
+      const newtext = 'asdasd\n';
+
+      const diffed = createPatch('test', oldtext, newtext);
+      expect(applyPatch(oldtext, diffed)).to.equal(newtext);
+    });
+
+    it('handle two common text', function() {
+      const oldtext = 's';
+      const newtext = 'sdfsdf\n';
+      const diffed = createPatch('test', oldtext, newtext);
+      expect(applyPatch(oldtext, diffed)).to.equal(newtext);
+    });
+
+
   });
 
   describe('#applyPatches', function() {


### PR DESCRIPTION
This is related to issue https://github.com/kpdecker/jsdiff/issues/77

if previsousOperation doesn't exists, just continue.

also add two more test about this.