### PR TITLE
Generate library on 'npm install' and 'npm publish' automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   },
   "main": "./lib",
   "scripts": {
-    "test": "grunt"
+    "prepublish": "grunt build",
+    "test": "grunt test"
   },
-  "dependencies": {},
   "devDependencies": {
     "async": "^1.4.2",
     "babel": "^5.8.23",
@@ -60,6 +60,5 @@
     "semver": "^5.0.3",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.0"
-  },
-  "optionalDependencies": {}
+  }
 }


### PR DESCRIPTION
This allow to build automatically the `lib` folder when code is downloaded from GitHub and just before to upload it to npm. Also it removes empty dependencies objects.