### PR TITLE
Add a fix for applying 0-length destination patches

### DIFF
--- a/src/patch/apply.js
+++ b/src/patch/apply.js
@@ -81,6 +81,7 @@ export function applyPatch(source, uniDiff, options = {}) {
   for (let i = 0; i < hunks.length; i++) {
     let hunk = hunks[i],
         toPos = hunk.offset + hunk.newStart - 1;
+    if (hunk.newLines == 0) { toPos++; }
 
     for (let j = 0; j < hunk.lines.length; j++) {
       let line = hunk.lines[j],

--- a/test/patch/apply.js
+++ b/test/patch/apply.js
@@ -416,6 +416,23 @@ describe('patch/apply', function() {
           + 'line5\n');
     });
 
+    it('should erase a file', function() {
+      expect(applyPatch(
+          'line1\n'
+          + 'line2\n'
+          + 'line3\n'
+          + 'line4\n',
+
+          '--- test\theader1\n'
+          + '+++ test\theader2\n'
+          + '@@ -1,4 +0,0 @@\n'
+          + '-line1\n'
+          + '-line2\n'
+          + '-line3\n'
+          + '-line4\n'))
+        .to.equal('');
+    });
+
     it('should allow custom line comparison', function() {
       expect(applyPatch(
           'line2\n'


### PR DESCRIPTION
If the destination lines length is 0, then actual editing should start one line later (since, per the spec, zero-length blocks are indexed at the line **before** any changes). This closes #116.