### PR TITLE
Default oldStart and newStart values to 1 if NaN

### DIFF
--- a/src/patch/parse.js
+++ b/src/patch/parse.js
@@ -71,9 +71,9 @@ export function parsePatch(uniDiff, options = {}) {
         chunkHeader = chunkHeaderLine.split(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
 
     let hunk = {
-      oldStart: +chunkHeader[1],
+      oldStart: +chunkHeader[1] || 1,
       oldLines: +chunkHeader[2] || 1,
-      newStart: +chunkHeader[3],
+      newStart: +chunkHeader[3] || 1,
       newLines: +chunkHeader[4] || 1,
       lines: []
     };


### PR DESCRIPTION
In diffs with conflicting changes, set old and new starting values to 1 (or other default value) if NaN. Allows for easier json parsing, as NaN is not recognized by json.