### PR TITLE
Make README.md look nicer in npmjs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ or
 * `JsDiff.diffLines(oldStr, newStr[, options])` - diffs two blocks of text, comparing line by line.
 
     Options
-      * `ignoreWhitespace`: `true` to ignore leading and trailing whitespace. This is the same as `diffTrimmedLines`
-      * `newlineIsToken`: `true` to treat newline characters as separate tokens.  This allows for changes to the newline structure to occur independently of the line content and to be treated as such. In general this is the more human friendly form of `diffLines` and `diffLines` is better suited for patches and other computer friendly output.
+    * `ignoreWhitespace`: `true` to ignore leading and trailing whitespace. This is the same as `diffTrimmedLines`
+    * `newlineIsToken`: `true` to treat newline characters as separate tokens.  This allows for changes to the newline structure to occur independently of the line content and to be treated as such. In general this is the more human friendly form of `diffLines` and `diffLines` is better suited for patches and other computer friendly output.
 
     Returns a list of change objects (See below).
 


### PR DESCRIPTION
Options of JsDiff.diffLines are not parsed as list in npmjs.com (CommonMark) due to indentation. This PR fixes such indentation.