### PR TITLE
Split file using all possible line delimiter instead of hard-coded "/n" and join lines back using the original delimiters

### DIFF
--- a/src/patch/apply.js
+++ b/src/patch/apply.js
@@ -88,7 +88,7 @@ export function applyPatch(source, uniDiff, options = {}) {
       let line = hunk.lines[j],
           operation = line[0],
           content = line.substr(1),
-          delimiter = hunk.linedelimiters[j];
+          delimiter = hunk.linedelimiters[j] || "/n";
 
       if (operation === ' ') {
         toPos++;

--- a/src/patch/apply.js
+++ b/src/patch/apply.js
@@ -115,13 +115,13 @@ export function applyPatch(source, uniDiff, options = {}) {
   if (removeEOFNL) {
     while (!lines[lines.length - 1]) {
       lines.pop();
-      delimiters.pop()
+      delimiters.pop();
     }
   } else if (addEOFNL) {
     lines.push('');
     delimiters.push('\n');
   }
-  for(var _k = 0; _k < lines.length; _k ++){
+  for (let _k = 0; _k < lines.length; _k++) {
   	lines[_k] = lines[_k] + delimiters[_k];
   }
   return lines.join('');

--- a/src/patch/apply.js
+++ b/src/patch/apply.js
@@ -88,7 +88,7 @@ export function applyPatch(source, uniDiff, options = {}) {
       let line = hunk.lines[j],
           operation = line[0],
           content = line.substr(1),
-          delimiter = hunk.linedelimiters[j] || '\n';
+          delimiter = hunk.linedelimiters[j];
 
       if (operation === ' ') {
         toPos++;

--- a/src/patch/apply.js
+++ b/src/patch/apply.js
@@ -88,7 +88,7 @@ export function applyPatch(source, uniDiff, options = {}) {
       let line = hunk.lines[j],
           operation = line[0],
           content = line.substr(1),
-          delimiter = hunk.linedelimiters[j] || "/n";
+          delimiter = hunk.linedelimiters[j] || '\n';
 
       if (operation === ' ') {
         toPos++;

--- a/src/patch/apply.js
+++ b/src/patch/apply.js
@@ -122,7 +122,7 @@ export function applyPatch(source, uniDiff, options = {}) {
     delimiters.push('\n');
   }
   for (let _k = 0; _k < lines.length; _k++) {
-  	lines[_k] = lines[_k] + delimiters[_k];
+    lines[_k] = lines[_k] + delimiters[_k];
   }
   return lines.join('');
 }

--- a/src/patch/apply.js
+++ b/src/patch/apply.js
@@ -15,8 +15,8 @@ export function applyPatch(source, uniDiff, options = {}) {
   }
 
   // Apply the diff to the input
-  let lines = source.split(/\r\n|[\n\v\f\r\x85\u2028\u2029]/),
-      delimiters = source.match(/\r\n|[\n\v\f\r\x85\u2028\u2029]/g),
+  let lines = source.split(/\r\n|[\n\v\f\r\x85]/),
+      delimiters = source.match(/\r\n|[\n\v\f\r\x85]/g) || [],
       hunks = uniDiff.hunks,
 
       compareLine = options.compareLine || ((lineNumber, line, operation, patchContent) => line === patchContent),
@@ -121,7 +121,7 @@ export function applyPatch(source, uniDiff, options = {}) {
     lines.push('');
     delimiters.push('\n');
   }
-  for (let _k = 0; _k < lines.length; _k++) {
+  for (let _k = 0; _k < lines.length - 1; _k++) {
     lines[_k] = lines[_k] + delimiters[_k];
   }
   return lines.join('');

--- a/src/patch/parse.js
+++ b/src/patch/parse.js
@@ -77,7 +77,7 @@ export function parsePatch(uniDiff, options = {}) {
       newStart: +chunkHeader[3],
       newLines: +chunkHeader[4] || 1,
       lines: [],
-      linedelimiters:[]
+      linedelimiters: []
     };
 
     let addCount = 0,

--- a/src/patch/parse.js
+++ b/src/patch/parse.js
@@ -1,6 +1,6 @@
 export function parsePatch(uniDiff, options = {}) {
-  let diffstr = uniDiff.split(/\r\n|[\n\v\f\r\x85\u2028\u2029]/),
-      delimiters = uniDiff.match(/\r\n|[\n\v\f\r\x85\u2028\u2029]/g),
+  let diffstr = uniDiff.split(/\r\n|[\n\v\f\r\x85]/),
+      delimiters = uniDiff.match(/\r\n|[\n\v\f\r\x85]/g) || [],
       list = [],
       i = 0;
 
@@ -95,7 +95,7 @@ export function parsePatch(uniDiff, options = {}) {
 
       if (operation === '+' || operation === '-' || operation === ' ' || operation === '\\') {
         hunk.lines.push(diffstr[i]);
-        hunk.linedelimiters.push(delimiters[i]);
+        hunk.linedelimiters.push(delimiters[i] || '\n');
 
         if (operation === '+') {
           addCount++;

--- a/src/patch/parse.js
+++ b/src/patch/parse.js
@@ -1,5 +1,6 @@
 export function parsePatch(uniDiff, options = {}) {
-  let diffstr = uniDiff.split('\n'),
+  let diffstr = uniDiff.split(/\r\n|[\n\v\f\r\x85\u2028\u2029]/),
+      delimiters = uniDiff.match(/\r\n|[\n\v\f\r\x85\u2028\u2029]/g),
       list = [],
       i = 0;
 
@@ -75,7 +76,8 @@ export function parsePatch(uniDiff, options = {}) {
       oldLines: +chunkHeader[2] || 1,
       newStart: +chunkHeader[3],
       newLines: +chunkHeader[4] || 1,
-      lines: []
+      lines: [],
+      linedelimiters:[]
     };
 
     let addCount = 0,
@@ -93,6 +95,7 @@ export function parsePatch(uniDiff, options = {}) {
 
       if (operation === '+' || operation === '-' || operation === ' ' || operation === '\\') {
         hunk.lines.push(diffstr[i]);
+        hunk.linedelimiters.push(delimiters[i]);
 
         if (operation === '+') {
           addCount++;

--- a/test/patch/parse.js
+++ b/test/patch/parse.js
@@ -21,6 +21,12 @@ describe('patch/parse', function() {
                 ' line3',
                 '+line4',
                 ' line5'
+              ],
+              linedelimiters: [
+                '\n',
+                '\n',
+                '\n',
+                '\n'
               ]
             }
           ]
@@ -39,6 +45,10 @@ describe('patch/parse', function() {
               lines: [
                 '-line3',
                 '+line4'
+              ],
+              linedelimiters: [
+                '\n',
+                '\n'
               ]
             }
           ]
@@ -66,6 +76,12 @@ describe('patch/parse', function() {
                 ' line3',
                 '+line4',
                 ' line5'
+              ],
+              linedelimiters: [
+                '\n',
+                '\n',
+                '\n',
+                '\n'
               ]
             },
             {
@@ -76,6 +92,12 @@ describe('patch/parse', function() {
                 ' line3',
                 '-line4',
                 ' line5'
+              ],
+              linedelimiters: [
+                '\n',
+                '\n',
+                '\n',
+                '\n'
               ]
             }
           ]
@@ -107,6 +129,12 @@ describe('patch/parse', function() {
                 ' line3',
                 '+line4',
                 ' line5'
+              ],
+              linedelimiters: [
+                '\n',
+                '\n',
+                '\n',
+                '\n'
               ]
             }
           ]
@@ -147,6 +175,12 @@ Index: test2
                 ' line3',
                 '+line4',
                 ' line5'
+              ],
+              linedelimiters: [
+                '\n',
+                '\n',
+                '\n',
+                '\n'
               ]
             }
           ]
@@ -165,6 +199,12 @@ Index: test2
                 ' line3',
                 '+line4',
                 ' line5'
+              ],
+              linedelimiters: [
+                '\n',
+                '\n',
+                '\n',
+                '\n'
               ]
             }
           ]
@@ -201,6 +241,12 @@ Index: test2
                 ' line3',
                 '+line4',
                 ' line5'
+              ],
+              linedelimiters: [
+                '\n',
+                '\n',
+                '\n',
+                '\n'
               ]
             }
           ]
@@ -218,6 +264,12 @@ Index: test2
                 ' line3',
                 '+line4',
                 ' line5'
+              ],
+              linedelimiters: [
+                '\n',
+                '\n',
+                '\n',
+                '\n'
               ]
             }
           ]
@@ -237,6 +289,10 @@ Index: test2
               lines: [
                 '-line5',
                 '\\ No newline at end of file'
+              ],
+              linedelimiters: [
+                '\n',
+                '\n'
               ]
             }
           ]
@@ -255,6 +311,10 @@ Index: test2
               lines: [
                 '+line5',
                 '\\ No newline at end of file'
+              ],
+              linedelimiters: [
+                '\n',
+                '\n'
               ]
             }
           ]
@@ -275,6 +335,11 @@ Index: test2
                 '+line4',
                 ' line5',
                 '\\ No newline at end of file'
+              ],
+              linedelimiters: [
+                '\n',
+                '\n',
+                '\n'
               ]
             }
           ]


### PR DESCRIPTION
Split file using all possible line delimiter instead of hard-coded "/n" and join lines back using the original delimiters. 
let me know your feed back on this please.
