### PR TITLE
JsDiff.diffArrays to compare arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ or
 
     Returns a list of change objects (See below).
 
+* `JsDiff.diffArrays(oldArr, newArr[, options])` - diffs two arrays, comparing each item for strict equality (===).
+
+    Returns a list of change objects (See below).
+
 * `JsDiff.createTwoFilesPatch(oldFileName, newFileName, oldStr, newStr, oldHeader, newHeader)` - creates a unified diff patch.
 
     Parameters:

--- a/src/diff/array.js
+++ b/src/diff/array.js
@@ -1,0 +1,8 @@
+import Diff from './base';
+
+export const arrayDiff = new Diff();
+arrayDiff.tokenize = arrayDiff.join = function(value) {
+  return value;
+};
+
+export function diffArrays(oldArr, newArr, callback) { return arrayDiff.diff(oldArr, newArr, callback); }

--- a/src/diff/array.js
+++ b/src/diff/array.js
@@ -2,7 +2,7 @@ import Diff from './base';
 
 export const arrayDiff = new Diff();
 arrayDiff.tokenize = arrayDiff.join = function(value) {
-  return value;
+  return value.slice();
 };
 
 export function diffArrays(oldArr, newArr, callback) { return arrayDiff.diff(oldArr, newArr, callback); }

--- a/src/diff/base.js
+++ b/src/diff/base.js
@@ -36,7 +36,7 @@ Diff.prototype = {
     let oldPos = this.extractCommon(bestPath[0], newString, oldString, 0);
     if (bestPath[0].newPos + 1 >= newLen && oldPos + 1 >= oldLen) {
       // Identity per the equality and tokenizer
-      return done([{value: newString.join(''), count: newString.length}]);
+      return done([{value: this.join(newString), count: newString.length}]);
     }
 
     // Main worker method. checks all permutations of a given edit length for acceptance.

--- a/src/diff/base.js
+++ b/src/diff/base.js
@@ -160,6 +160,9 @@ Diff.prototype = {
   },
   tokenize(value) {
     return value.split('');
+  },
+  join(chars) {
+    return chars.join('');
   }
 };
 
@@ -179,9 +182,9 @@ function buildValues(diff, components, newString, oldString, useLongestToken) {
           return oldValue.length > value.length ? oldValue : value;
         });
 
-        component.value = value.join('');
+        component.value = diff.join(value);
       } else {
-        component.value = newString.slice(newPos, newPos + component.count).join('');
+        component.value = diff.join(newString.slice(newPos, newPos + component.count));
       }
       newPos += component.count;
 
@@ -190,7 +193,7 @@ function buildValues(diff, components, newString, oldString, useLongestToken) {
         oldPos += component.count;
       }
     } else {
-      component.value = oldString.slice(oldPos, oldPos + component.count).join('');
+      component.value = diff.join(oldString.slice(oldPos, oldPos + component.count));
       oldPos += component.count;
 
       // Reverse add and remove so removes are output first to match common convention

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,8 @@ import {diffSentences} from './diff/sentence';
 import {diffCss} from './diff/css';
 import {diffJson, canonicalize} from './diff/json';
 
+import {diffArrays} from './diff/array';
+
 import {applyPatch, applyPatches} from './patch/apply';
 import {parsePatch} from './patch/parse';
 import {structuredPatch, createTwoFilesPatch, createPatch} from './patch/create';
@@ -42,6 +44,8 @@ export {
 
   diffCss,
   diffJson,
+
+  diffArrays,
 
   structuredPatch,
   createTwoFilesPatch,

--- a/test/diff/array.js
+++ b/test/diff/array.js
@@ -1,0 +1,19 @@
+import {diffArrays} from '../../lib/diff/array';
+
+import {expect} from 'chai';
+
+describe('diff/array', function() {
+  describe('#diffArrays', function() {
+    it('Should diff arrays', function() {
+      const a = {a: 0}, b = {b: 1}, c = {c: 2};
+      const diffResult = diffArrays([a, b, c], [a, c, b]);
+      console.log(diffResult);
+      expect(diffResult).to.deep.equals([
+          {count: 1, value: [a]},
+          {count: 1, value: [c], removed: undefined, added: true},
+          {count: 1, value: [b]},
+          {count: 1, value: [c], removed: true, added: undefined}
+      ]);
+    });
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,8 @@ describe('root exports', function() {
     expect(Diff.diffCss).to.exist;
     expect(Diff.diffJson).to.exist;
 
+    expect(Diff.diffArrays).to.exist;
+
     expect(Diff.structuredPatch).to.exist;
     expect(Diff.createTwoFilesPatch).to.exist;
     expect(Diff.createPatch).to.exist;


### PR DESCRIPTION
adds support for comparing two arrays and finding the difference. This comes in very handy in my current project. 
If you feel this is beyond the boundaries of the primary focus of jsdiff which is text comparison, I could trim the pull request to just having the .join method move to the base class so we can create the diffArrays in our own project. Having the .join('') in several methods of base prevents this.
