### PR TITLE
Add browser field pointing to dist/diff.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "node": ">=0.3.1"
   },
   "main": "./lib",
+  "browser": "./dist/diff.js',
   "scripts": {
     "test": "grunt"
   },


### PR DESCRIPTION
Having the browser field in package.json point to the bundle will provide better support for unpkg.com and bundlers wanting to use the dist file etc.