### PR TITLE
Docs: Replace grunt with npm test in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,10 @@ Generally we like to see pull requests that
 
 ```
 npm install
-grunt
+npm test
 ````
 
-The `grunt dev` implements watching for tests within Node and `karma start` may be used for manual testing in browsers.
+The `npm test -- dev` implements watching for tests within Node and `karma start` may be used for manual testing in browsers.
 
 If you notice any problems, please report them to the GitHub issue tracker at
 [http://github.com/kpdecker/jsdiff/issues](http://github.com/kpdecker/jsdiff/issues).


### PR DESCRIPTION
`grunt: command not found` because `grunt` isn’t installed globally on my computer?

The project installs it locally and therefore I can run it via `npm`

```json
  "scripts": {
    "test": "grunt"
  },
```