### PR TITLE
Fix: diffArrays can compare falsey items

### DIFF
--- a/src/diff/array.js
+++ b/src/diff/array.js
@@ -4,5 +4,8 @@ export const arrayDiff = new Diff();
 arrayDiff.tokenize = arrayDiff.join = function(value) {
   return value.slice();
 };
+arrayDiff.removeEmpty = function(value) {
+  return value;
+};
 
 export function diffArrays(oldArr, newArr, callback) { return arrayDiff.diff(oldArr, newArr, callback); }

--- a/test/diff/array.js
+++ b/test/diff/array.js
@@ -15,5 +15,23 @@ describe('diff/array', function() {
           {count: 1, value: [c], removed: true, added: undefined}
       ]);
     });
+    it('should diff falsey values', function() {
+      const a = false;
+      const b = 0;
+      const c = '';
+      // Example sequences from Myers 1986
+      const arrayA = [c, b, a, b, a, c];
+      const arrayB = [a, b, c, a, b, b, a];
+      const diffResult = diffArrays(arrayA, arrayB);
+      expect(diffResult).to.deep.equals([
+        {count: 2, value: [a, b], removed: undefined, added: true},
+        {count: 1, value: [c]},
+        {count: 1, value: [b], removed: true, added: undefined},
+        {count: 2, value: [a, b]},
+        {count: 1, value: [b], removed: undefined, added: true},
+        {count: 1, value: [a]},
+        {count: 1, value: [c], removed: true, added: undefined}
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Fixes #173 

* Override `removeEmpty` method
* Add a test that failed first