### PR TITLE
Added buffer diff configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   "scripts": {
     "test": "grunt"
   },
-  "dependencies": {},
+  "dependencies": {
+    "buffer": "^5.0.8"
+  },
   "devDependencies": {
     "async": "^1.4.2",
     "babel-core": "^6.0.0",

--- a/src/diff/buffer.js
+++ b/src/diff/buffer.js
@@ -1,0 +1,17 @@
+import {Buffer} from 'buffer';
+import Diff from './base';
+
+export const bufferDiff = new Diff();
+export function diffBytes(oldBuffer, newBuffer, options) { return bufferDiff.diff(oldBuffer, newBuffer, options); }
+
+/* Buffer itself can be accessed with array index syntax */
+bufferDiff.tokenize = (input) => input;
+bufferDiff.castInput = (input) => input;
+
+/* Simply create a buffer from the bytes */
+bufferDiff.join = (bytes) => {
+    return Buffer.from(bytes);
+};
+
+/* There is no notion of "empty" in buffer */
+bufferDiff.removeEmpty = (input) => input;

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@
  *
  * JsDiff.diffCss: Diff targeted at CSS content
  *
+ * JsDiff.diffBytes: Diff targeted at buffers (byte arrays)
+ *
  * These methods are based on the implementation proposed in
  * "An O(ND) Difference Algorithm and its Variations" (Myers, 1986).
  * http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.4.6927
@@ -24,6 +26,8 @@ import {diffCss} from './diff/css';
 import {diffJson, canonicalize} from './diff/json';
 
 import {diffArrays} from './diff/array';
+
+import {diffBytes} from './diff/buffer';
 
 import {applyPatch, applyPatches} from './patch/apply';
 import {parsePatch} from './patch/parse';
@@ -47,6 +51,8 @@ export {
   diffJson,
 
   diffArrays,
+
+  diffBytes,
 
   structuredPatch,
   createTwoFilesPatch,

--- a/test/diff/buffer.js
+++ b/test/diff/buffer.js
@@ -1,0 +1,40 @@
+import {diffBytes} from '../../lib/diff/buffer';
+import {convertChangesToXML} from '../../lib/convert/xml';
+
+import {expect} from 'chai';
+
+describe('diff/buffer', function() {
+    describe('#diffBytes', function() {
+        it('Should diff bytes', function() {
+            const diffResult = diffBytes(Buffer.from('New Value.'), Buffer.from('New ValueMoreData.'));
+            const diffResultWithStringValues = diffResult.map((change) => Object.assign({}, change, {value: change.value.toString()}));
+            expect(convertChangesToXML(diffResultWithStringValues)).to.equal('New Value<ins>MoreData</ins>.');
+        });
+
+        describe('unicode character bytes', function() {
+            it('will not be counted as a single character', function() {
+                // Fóó: [46 C3 B3 C3 B3]
+                // Föó: [46 C3 B6 C3 B3]
+                const diffResult = diffBytes(Buffer.from('Fóó'), Buffer.from('Föó'));
+                const diffResultWithByteArrays = diffResult.map((change) => Object.assign({}, change, {value: [...change.value]}));
+
+                expect(diffResultWithByteArrays.length).to.equal(4);
+
+                // First two bytes are the same
+                expect(diffResultWithByteArrays[0].count).to.equal(2);
+                expect(diffResultWithByteArrays[0].value).to.eql([0x46, 0xC3]);
+
+                expect(diffResultWithByteArrays[1].count).to.equal(1);
+                expect(diffResultWithByteArrays[1].removed).to.equal(true);
+                expect(diffResultWithByteArrays[1].value).to.eql([0xB3]);
+
+                expect(diffResultWithByteArrays[2].count).to.equal(1);
+                expect(diffResultWithByteArrays[2].added).to.equal(true);
+                expect(diffResultWithByteArrays[2].value).to.eql([0xB6]);
+
+                expect(diffResultWithByteArrays[3].count).to.equal(2);
+                expect(diffResultWithByteArrays[3].value).to.eql([0xC3, 0xB3]);
+            });
+        });
+    });
+});


### PR DESCRIPTION
In my application I needed a way to apply diff to binary data.

My first attempt was to convert buffers to strings using `buffer.toString('binary')` but because the algorithm makes calls to `.join()` the resulting string was in UTF-8 encoding with extra characters for unicode characters outside ASCII range.

I ended up adding support for buffer directly so that changes properly contain the number of bytes in the `count` and the `value` is also a buffer which can then be converted to any of your favorite string encodings.