### PR TITLE
Omit redundant slice in join method of diffArrays

### DIFF
--- a/src/diff/array.js
+++ b/src/diff/array.js
@@ -1,10 +1,10 @@
 import Diff from './base';
 
 export const arrayDiff = new Diff();
-arrayDiff.tokenize = arrayDiff.join = function(value) {
+arrayDiff.tokenize = function(value) {
   return value.slice();
 };
-arrayDiff.removeEmpty = function(value) {
+arrayDiff.join = arrayDiff.removeEmpty = function(value) {
   return value;
 };
 

--- a/test/diff/array.js
+++ b/test/diff/array.js
@@ -33,7 +33,35 @@ describe('diff/array', function() {
         {count: 1, value: [c], removed: true, added: undefined}
       ]);
     });
+    describe('anti-aliasing', function() {
+      // Test apparent contract that no chunk value is ever an input argument.
+      const value = [0, 1, 2];
+      const expected = [
+        {count: value.length, value: value}
+      ];
 
+      const input = value.slice();
+      const diffResult = diffArrays(input, input);
+      it('returns correct deep result for identical inputs', function() {
+        expect(diffResult).to.deep.equals(expected);
+      });
+      it('does not return the input array', function() {
+        expect(diffResult[0].value).to.not.equal(input);
+      });
+
+      const input1 = value.slice();
+      const input2 = value.slice();
+      const diffResult2 = diffArrays(input1, input2);
+      it('returns correct deep result for equivalent inputs', function() {
+        expect(diffResult2).to.deep.equals(expected);
+      });
+      it('does not return the first input array', function() {
+        expect(diffResult2[0].value).to.not.equal(input1);
+      });
+      it('does not return the second input array', function() {
+        expect(diffResult2[0].value).to.not.equal(input2);
+      });
+    });
     it('Should diff arrays with comparator', function() {
       const a = {a: 0}, b = {a: 1}, c = {a: 2}, d = {a: 3};
       function comparator(left, right) {


### PR DESCRIPTION
In `buildValues` for `diffArray` the `value` property is an array, therefore the `slice` in the `join` method of the derived class is redundant, especially because the value is usually the result of `slice`

https://github.com/kpdecker/jsdiff/blob/master/src/diff/base.js#L181-L213

Because of the `slice` in the `tokenize` method of derived class, I added tests to prevent regression in apparent contract that no chunk value is ever an input argument. When I temporarily replaced `return value.slice();` with `return value;` two of the new assertions failed:
* does not return the input array
* does not return the second input array

However, all the existing tests passed, so if for equal or equivalent arrays, you see no problem with returning an input array as value of the one output chunk, then I am happy to update PR.