### PR TITLE
Support patches with empty lines (#159)

### DIFF
--- a/src/patch/apply.js
+++ b/src/patch/apply.js
@@ -91,8 +91,8 @@ export function applyPatch(source, uniDiff, options = {}) {
 
     for (let j = 0; j < hunk.lines.length; j++) {
       let line = hunk.lines[j],
-          operation = line[0],
-          content = line.substr(1),
+          operation = line.length>0 ? line[0] : ' ',
+          content = line.length>0 ? line.substr(1) : line,
           delimiter = hunk.linedelimiters[j];
 
       if (operation === ' ') {

--- a/src/patch/apply.js
+++ b/src/patch/apply.js
@@ -34,8 +34,8 @@ export function applyPatch(source, uniDiff, options = {}) {
   function hunkFits(hunk, toPos) {
     for (let j = 0; j < hunk.lines.length; j++) {
       let line = hunk.lines[j],
-          operation = line[0],
-          content = line.substr(1);
+          operation = line.length>0 ? line[0] : ' ',
+          content = line.length>0 ? line.substr(1) : line;
 
       if (operation === ' ' || operation === '-') {
         // Context sanity check

--- a/src/patch/apply.js
+++ b/src/patch/apply.js
@@ -34,8 +34,8 @@ export function applyPatch(source, uniDiff, options = {}) {
   function hunkFits(hunk, toPos) {
     for (let j = 0; j < hunk.lines.length; j++) {
       let line = hunk.lines[j],
-          operation = line.length>0 ? line[0] : ' ',
-          content = line.length>0 ? line.substr(1) : line;
+          operation = (line.length > 0 ? line[0] : ' '),
+          content = (line.length > 0 ? line.substr(1) : line);
 
       if (operation === ' ' || operation === '-') {
         // Context sanity check
@@ -91,8 +91,8 @@ export function applyPatch(source, uniDiff, options = {}) {
 
     for (let j = 0; j < hunk.lines.length; j++) {
       let line = hunk.lines[j],
-          operation = line.length>0 ? line[0] : ' ',
-          content = line.length>0 ? line.substr(1) : line,
+          operation = (line.length > 0 ? line[0] : ' '),
+          content = (line.length > 0 ? line.substr(1) : line),
           delimiter = hunk.linedelimiters[j];
 
       if (operation === ' ') {

--- a/src/patch/parse.js
+++ b/src/patch/parse.js
@@ -95,7 +95,7 @@ export function parsePatch(uniDiff, options = {}) {
             && diffstr[i + 2].indexOf('@@') === 0) {
           break;
       }
-      let operation = (diffstr[i].length==0 && i!=diffstr.length-1) ? ' ' : diffstr[i][0];
+      let operation = (diffstr[i].length == 0 && i != (diffstr.length - 1)) ? ' ' : diffstr[i][0];
 
       if (operation === '+' || operation === '-' || operation === ' ' || operation === '\\') {
         hunk.lines.push(diffstr[i]);

--- a/src/patch/parse.js
+++ b/src/patch/parse.js
@@ -95,7 +95,7 @@ export function parsePatch(uniDiff, options = {}) {
             && diffstr[i + 2].indexOf('@@') === 0) {
           break;
       }
-      let operation = diffstr[i].length>0 ? diffstr[i][0] : ' ';
+      let operation = (diffstr[i].length==0 && i!=diffstr.length-1) ? ' ' : diffstr[i][0];
 
       if (operation === '+' || operation === '-' || operation === ' ' || operation === '\\') {
         hunk.lines.push(diffstr[i]);

--- a/src/patch/parse.js
+++ b/src/patch/parse.js
@@ -95,7 +95,7 @@ export function parsePatch(uniDiff, options = {}) {
             && diffstr[i + 2].indexOf('@@') === 0) {
           break;
       }
-      let operation = diffstr[i][0];
+      let operation = diffstr[i].length>0 ? diffstr[i][0] : ' ';
 
       if (operation === '+' || operation === '-' || operation === ' ' || operation === '\\') {
         hunk.lines.push(diffstr[i]);


### PR DESCRIPTION
Currently, patches with empty lines such as:
```
-<link rel="resource" type="application/l10n" href="locale/locale.properties">
-<script src="pdf.viewer.js"></script>

+<!-- == INSERTS == -->

```
are not fully applied because the parser stops at the empty line and the following operation is ignored.