### PR TITLE
Remove duplicated release notes for v3.5.0

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -11,15 +11,6 @@
 - Optimize parch header parser - 2aec429
 - Fix typos - e89c832
 
-[Commits](https://github.com/kpdecker/jsdiff/compare/v3.5.0...v3.5.0)
-
-## v3.5.0 - March 4th, 2018
-- Omit redundant slice in join method of diffArrays - 1023590
-- Support patches with empty lines - fb0f208
-- Accept a custom JSON replacer function for JSON diffing - 69c7f0a
-- Optimize parch header parser - 2aec429
-- Fix typos - e89c832
-
 [Commits](https://github.com/kpdecker/jsdiff/compare/v3.4.0...v3.5.0)
 
 ## v3.4.0 - October 7th, 2017


### PR DESCRIPTION
The release notes appear twice, the commits list compares v3.5.0 to itself.