### PR TITLE
Make ()[]"' as word boundaries between each other

### DIFF
--- a/src/diff/word.js
+++ b/src/diff/word.js
@@ -32,7 +32,7 @@ wordDiff.equals = function(left, right) {
   return left === right || (this.options.ignoreWhitespace && !reWhitespace.test(left) && !reWhitespace.test(right));
 };
 wordDiff.tokenize = function(value) {
-  let tokens = value.split(/(\s+|\b)/);
+  let tokens = value.split(/(\s+|[()[\]{}'"]|\b)/);
 
   // Join the boundary splits that we do not consider to be boundaries. This is primarily the extended Latin character set.
   for (let i = 0; i < tokens.length - 1; i++) {

--- a/test/diff/word.js
+++ b/test/diff/word.js
@@ -184,6 +184,31 @@ describe('WordDiff', function() {
       expect(convertChangesToXML(diffResult)).to.equal('New<ins>  ValueMoreData</ins> <del>Value  </del>');
     });
 
+    it('should inserts values in parenthesis', function() {
+      const diffResult = diffWordsWithSpace('()', '(word)');
+      expect(convertChangesToXML(diffResult)).to.equal('(<ins>word</ins>)');
+    });
+
+    it('should inserts values in brackets', function() {
+      const diffResult = diffWordsWithSpace('[]', '[word]');
+      expect(convertChangesToXML(diffResult)).to.equal('[<ins>word</ins>]');
+    });
+
+    it('should inserts values in curly braces', function() {
+      const diffResult = diffWordsWithSpace('{}', '{word}');
+      expect(convertChangesToXML(diffResult)).to.equal('{<ins>word</ins>}');
+    });
+
+    it('should inserts values in quotes', function() {
+      const diffResult = diffWordsWithSpace("''", "'word'");
+      expect(convertChangesToXML(diffResult)).to.equal("'<ins>word</ins>'");
+    });
+
+    it('should inserts values in double quotes', function() {
+      const diffResult = diffWordsWithSpace('""', '"word"');
+      expect(convertChangesToXML(diffResult)).to.equal('&quot;<ins>word</ins>&quot;');
+    });
+
     it('should perform async operations', function(done) {
       diffWordsWithSpace('New Value  ', 'New  ValueMoreData ', function(err, diffResult) {
         expect(convertChangesToXML(diffResult)).to.equal('New<ins>  ValueMoreData</ins> <del>Value  </del>');


### PR DESCRIPTION
This produces more natural diffs in situations like `()` -> `(word)`