### PR TITLE
Fix: Missing "No newline at end of file" when comparing two texts that do not end in newlines

### DIFF
--- a/src/patch/create.js
+++ b/src/patch/create.js
@@ -71,10 +71,12 @@ export function structuredPatch(oldFileName, newFileName, oldStr, newStr, oldHea
             // EOF is inside this hunk
             let oldEOFNewline = (/\n$/.test(oldStr));
             let newEOFNewline = (/\n$/.test(newStr));
-            if (lines.length == 0 && !oldEOFNewline) {
+            let noNlBeforeAdds = lines.length == 0 && curRange.length > hunk.oldLines;
+            if (!oldEOFNewline && noNlBeforeAdds) {
               // special case: old has no eol and no trailing context; no-nl can end up before adds
               curRange.splice(hunk.oldLines, 0, '\\ No newline at end of file');
-            } else if (!oldEOFNewline || !newEOFNewline) {
+            }
+            if ((!oldEOFNewline && !noNlBeforeAdds) || !newEOFNewline) {
               curRange.push('\\ No newline at end of file');
             }
           }

--- a/test/patch/create.js
+++ b/test/patch/create.js
@@ -89,6 +89,22 @@ describe('patch/create', function() {
         + '+line4\n');
     });
 
+    it('should output "no newline" at end of file message on both missing nl', function() {
+      expect(createPatch('test', 'line1\nline2\nline3\nline4', 'line1\nline2\nline3\nline44', 'header1', 'header2')).to.equal(
+        'Index: test\n'
+        + '===================================================================\n'
+        + '--- test\theader1\n'
+        + '+++ test\theader2\n'
+        + '@@ -1,4 +1,4 @@\n'
+        + ' line1\n'
+        + ' line2\n'
+        + ' line3\n'
+        + '-line4\n'
+        + '\\ No newline at end of file\n'
+        + '+line44\n'
+        + '\\ No newline at end of file\n');
+    });
+
     it('should output "no newline" at end of file message on context missing nl', function() {
       expect(createPatch('test', 'line11\nline2\nline3\nline4', 'line1\nline2\nline3\nline4', 'header1', 'header2')).to.equal(
         'Index: test\n'
@@ -101,6 +117,33 @@ describe('patch/create', function() {
         + ' line2\n'
         + ' line3\n'
         + ' line4\n'
+        + '\\ No newline at end of file\n');
+    });
+
+    it('should output only one "no newline" at end of file message on empty file', function() {
+      expect(createPatch('test', '', 'line1\nline2\nline3\nline4', 'header1', 'header2')).to.equal(
+        'Index: test\n'
+        + '===================================================================\n'
+        + '--- test\theader1\n'
+        + '+++ test\theader2\n'
+        + '@@ -1,0 +1,4 @@\n'
+        + '\\ No newline at end of file\n'
+        + '+line1\n'
+        + '+line2\n'
+        + '+line3\n'
+        + '+line4\n'
+        + '\\ No newline at end of file\n');
+
+      expect(createPatch('test', 'line1\nline2\nline3\nline4', '', 'header1', 'header2')).to.equal(
+        'Index: test\n'
+        + '===================================================================\n'
+        + '--- test\theader1\n'
+        + '+++ test\theader2\n'
+        + '@@ -1,4 +1,0 @@\n'
+        + '-line1\n'
+        + '-line2\n'
+        + '-line3\n'
+        + '-line4\n'
         + '\\ No newline at end of file\n');
     });
 


### PR DESCRIPTION
Fixes #94