### PR TITLE
added word wrap on results div

### DIFF
--- a/style.css
+++ b/style.css
@@ -79,3 +79,9 @@ ins {
 		height: 99%; /* Hide scroll bar in Firefox */
 	}
 }
+
+// for readability, wrap words in results, 
+// in case the original text does not have line breaks
+#result {
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
Thanks for the great repo!

I am suggesting a minor change to improve readability of results, by adding a word wrap for the use case when the compared text doesn't have line space and it's all on one line, it make it easier to ready in results.

## Before 

<img width="1457" alt="screen shot 2018-09-16 at 13 18 15" src="https://user-images.githubusercontent.com/4661975/45596403-47d18c80-b9b3-11e8-9600-81441eb6afc0.png">


## After

```css
#result {
    white-space: pre-wrap;
}
```

<img width="1457" alt="screen shot 2018-09-16 at 13 19 31" src="https://user-images.githubusercontent.com/4661975/45596398-41431500-b9b3-11e8-81bf-9d2396324371.png">



