### PR TITLE
Revert to original factory naming

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ export default [
     input: 'src/index.js',
     output: [
       {
-        name: 'Diff',
+        name: 'JsDiff',
         file: pkg.browser,
         format: 'umd'
       },


### PR DESCRIPTION
* This builds the correct `JsDiff` factory name to match the current docs

NOTES:
* Option 1
* No other testing/verification performed

Closes #243 and closes #245 PR