### PR TITLE
Separate patch creation from serialization.

### DIFF
--- a/src/patch/create.js
+++ b/src/patch/create.js
@@ -99,12 +99,10 @@ export function structuredPatch(oldFileName, newFileName, oldStr, newStr, oldHea
   };
 }
 
-export function createTwoFilesPatch(oldFileName, newFileName, oldStr, newStr, oldHeader, newHeader, options) {
-  const diff = structuredPatch(oldFileName, newFileName, oldStr, newStr, oldHeader, newHeader, options);
-
+export function formatPatch(diff) {
   const ret = [];
-  if (oldFileName == newFileName) {
-    ret.push('Index: ' + oldFileName);
+  if (diff.oldFileName == diff.newFileName) {
+    ret.push('Index: ' + diff.oldFileName);
   }
   ret.push('===================================================================');
   ret.push('--- ' + diff.oldFileName + (typeof diff.oldHeader === 'undefined' ? '' : '\t' + diff.oldHeader));
@@ -121,6 +119,10 @@ export function createTwoFilesPatch(oldFileName, newFileName, oldStr, newStr, ol
   }
 
   return ret.join('\n') + '\n';
+}
+
+export function createTwoFilesPatch(oldFileName, newFileName, oldStr, newStr, oldHeader, newHeader, options) {
+  return formatPatch(structuredPatch(oldFileName, newFileName, oldStr, newStr, oldHeader, newHeader, options));
 }
 
 export function createPatch(fileName, oldStr, newStr, oldHeader, newHeader, options) {

--- a/test/patch/create.js
+++ b/test/patch/create.js
@@ -1,5 +1,5 @@
 import {diffWords} from '../../lib';
-import {createPatch, createTwoFilesPatch, structuredPatch} from '../../lib/patch/create';
+import {createPatch, createTwoFilesPatch, formatPatch, structuredPatch} from '../../lib/patch/create';
 
 import {expect} from 'chai';
 
@@ -649,6 +649,21 @@ describe('patch/create', function() {
           lines: [' line2', ' line3', '-line4', '+line5', '\\ No newline at end of file']
         }]
       });
+    });
+  });
+
+  describe('#formatPatch', function() {
+    it('should generate a patch string from an input diff', function() {
+      const res = formatPatch(structuredPatch(
+        'oldfile', 'newfile',
+        'line2\nline3\nline4\n', 'line2\nline3\nline5',
+        'header1', 'header2'
+      ));
+      expect(res).to.equal(createTwoFilesPatch(
+        'oldfile', 'newfile',
+        'line2\nline3\nline4\n', 'line2\nline3\nline5',
+        'header1', 'header2'
+      ));
     });
   });
 });


### PR DESCRIPTION
This allows for using a structured patch and serializing it later on.

Currently, when I want to work with the hunks and have a string version of the patch later on, I need to perform the diff twice.