### PR TITLE
wrap the result column

### DIFF
--- a/style.css
+++ b/style.css
@@ -43,6 +43,10 @@ ins {
 	text-decoration: none;
 }
 
+#result {
+	white-space: pre-wrap;
+}
+
 #settings {
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
I use this tool regularly. (thanks for making it)

Once thing that usually bugs me is how long lines are handled. So here's a small fix.

Before:
![image](https://user-images.githubusercontent.com/39191/59539681-08d55680-8eb3-11e9-9a38-d6c79cf60155.png)


After:
![image](https://user-images.githubusercontent.com/39191/59539690-125ebe80-8eb3-11e9-907b-fac4b95e1c6a.png)
