### PR TITLE
Added keywords to improve npm discoverability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "A javascript text diff implementation.",
   "keywords": [
     "diff",
+    "jsdiff",
+    "compare",
+    "patch",
+    "text",
+    "json",
+    "css",
     "javascript"
   ],
   "maintainers": [


### PR DESCRIPTION
A [search for `jsdiff` on npmjs.com](https://www.npmjs.com/search?q=jsdiff) does not include *jsdiff* in the results, though an apparent imposter is the number one hit. 

I added some additional keywords which I believe will help people find the diff tool they are looking for 😉 , but feel free to edit this pull request as you see fit.