### PR TITLE
Feat: Add `exports` map for Native ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.es6.js",
   "browser": "./dist/diff.js",
+  "unpkg": "./dist/diff.js",
   "exports": {
     ".": {
       "import": "./lib/index.mjs",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,14 @@
   "main": "./lib/index.js",
   "module": "./lib/index.es6.js",
   "browser": "./dist/diff.js",
+  "exports": {
+    ".": {
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js"
+    },
+    "./package.json": "./package.json",
+    "./": "./"
+  },
   "scripts": {
     "clean": "rm -rf lib/ dist/",
     "build:node": "yarn babel --out-dir lib  --source-maps=inline src",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,10 +8,16 @@ export default [
     output: [
       {
         name: 'Diff',
-        file: pkg.browser,
-        format: 'umd'
+        format: 'umd',
+        file: pkg.browser
       },
-      { file: pkg.module, format: 'es' }
+      {
+        format: 'esm',
+        file: pkg.module
+      }, {
+        format: 'esm',
+        file: pkg['exports']['.'].import
+      }
     ],
     plugins: [
       babel({


### PR DESCRIPTION
Closes #292 

Used the "loose" variant so that this won't be accidentally breaking for users who are spelunking into the `dist` or `lib` directories for specific file(s). 

There's an issue with Node 13.0 through 13.6 that shipped early, now-deprecated versions of the `exports` map syntax. 
Any users on those versions _should have already_ abandoned them, since any odd major release (especially early versions of it) are always experimental.

The current `exports` map works in all 12.x and 14.x versions (and 13.7+). 
It's completely ignored by older versions of Node since they don't know what it is.

---

While completely unrelated, I also added the `unpkg` key so that developers can do this, if they want:

```html
<script src="https://unpkg.com/diff"></script>
```