### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 sudo: false
+
 env:
   global:
     - secure: fyHOH0NftlAdy2tQawAq+qqcnc7GWo7ojRl5oHi30ueu79wFWTTWWvARCA8eo+FtWZsGlLfvyuzpmjnbJfMaN3wCzVfCG8ddd+nDhYKYbA4j+iqJarELQlVY5QguVGryO1emRPxFg2+WaSiaHCEvp5/eC7KYyHmlGtq0K0y1Svc=
@@ -11,7 +12,9 @@ matrix:
   include:
     - node_js: '10'
       env: KARMA=
-
+    - node_js: '10'
+      arch: ppc64le  
+      env: KARMA= 
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.org/github/nageshlop/jsdiff/builds/745639024