### PR TITLE
Fix online demo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Open the above .html file in a browser and you should see
 
 <img src="images/web_example.png" alt="Node Example">
 
-**[Full online demo](http://kpdecker.github.com/jsdiff)**
+**[Full online demo](https://kpdecker.github.io/jsdiff)**
 
 ## Compatibility
 


### PR DESCRIPTION
GitHub pages now uses github.io domain.

Since https://kpdecker.github.io/jsdiff redirects to http://incaseofstairs.com/jsdiff/ we could also use this URL.