### PR TITLE
Update demo link to point to github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Open the above .html file in a browser and you should see
 
 <img src="images/web_example.png" alt="Node Example">
 
-**[Full online demo](http://kpdecker.github.io/jsdiff)**
+**[Full online demo](https://kpdecker.github.io/jsdiff)**
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Open the above .html file in a browser and you should see
 
 <img src="images/web_example.png" alt="Node Example">
 
-**[Full online demo](http://kpdecker.github.com/jsdiff)**
+**[Full online demo](http://kpdecker.github.io/jsdiff)**
 
 ## Compatibility
 


### PR DESCRIPTION
This commit updated the link in the README.md file to point to the actual gh-pages hosted demo at https://kpdecker.github.io/jsdiff