### PR TITLE
Document and test options to createPatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ npm install diff --save
     * `newStr` : New string value
     * `oldHeader` : Additional information to include in the old file header
     * `newHeader` : Additional information to include in the new file header
-    * `options` : An object with options. Currently, only `context` is supported and describes how many lines of context should be included.
+    * `options` : An object with options. 
+      - `context` describes how many lines of context should be included.
+      - `ignoreWhitespace`: `true` to ignore leading and trailing whitespace.
 
 * `Diff.createPatch(fileName, oldStr, newStr, oldHeader, newHeader)` - creates a unified diff patch.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ npm install diff --save
     * `options` : An object with options. 
       - `context` describes how many lines of context should be included.
       - `ignoreWhitespace`: `true` to ignore leading and trailing whitespace.
+      - `newlineIsToken`: `true` to treat newline characters as separate tokens. This allows for changes to the newline structure to occur independently of the line content and to be treated as such. In general this is the more human friendly form of `diffLines` and `diffLines` is better suited for patches and other computer friendly output.
 
 * `Diff.createPatch(fileName, oldStr, newStr, oldHeader, newHeader)` - creates a unified diff patch.
 

--- a/test/patch/create.js
+++ b/test/patch/create.js
@@ -662,6 +662,47 @@ describe('patch/create', function() {
         expect(diffResult).to.equal(expectedResult);
       });
     });
+
+    describe('newlineIsToken', function() {
+      it('newlineIsToken: false', function() {
+        const expectedResult =
+          'Index: testFileName\n'
+          + '===================================================================\n'
+          + '--- testFileName\n'
+          + '+++ testFileName\n'
+          + '@@ -1,2 +1,2 @@\n'
+
+          // Diff is shown as entire row, eventhough text is unchanged
+          + '-line\n'
+          + '+line\r\n'
+
+          + ' line\n'
+          + '\\ No newline at end of file\n';
+
+        const diffResult = createPatch('testFileName', 'line\nline', 'line\r\nline', undefined, undefined, {newlineIsToken: false});
+        expect(diffResult).to.equal(expectedResult);
+      });
+
+      it('newlineIsToken: true', function() {
+        const expectedResult =
+          'Index: testFileName\n'
+          + '===================================================================\n'
+          + '--- testFileName\n'
+          + '+++ testFileName\n'
+          + '@@ -1,3 +1,3 @@\n'
+          + ' line\n'
+
+          // Newline change is shown as a single diff
+          + '-\n'
+          + '+\r\n'
+
+          + ' line\n'
+          + '\\ No newline at end of file\n';
+
+        const diffResult = createPatch('testFileName', 'line\nline', 'line\r\nline', undefined, undefined, {newlineIsToken: true});
+        expect(diffResult).to.equal(expectedResult);
+      });
+    });
   });
 
   describe('#structuredPatch', function() {

--- a/test/patch/create.js
+++ b/test/patch/create.js
@@ -631,6 +631,37 @@ describe('patch/create', function() {
       const diffResult = createTwoFilesPatch('foo', 'bar', '', '');
       expect(diffResult).to.equal(expectedResult);
     });
+
+    describe('ignoreWhitespace', function() {
+      it('ignoreWhitespace: false', function() {
+        const expectedResult =
+          'Index: testFileName\n'
+          + '===================================================================\n'
+          + '--- testFileName\n'
+          + '+++ testFileName\n'
+          + '@@ -1,2 +1,2 @@\n'
+          + '-line   \n'
+          + '- line\n'
+          + '\\ No newline at end of file\n'
+          + '+line\n'
+          + '+line\n'
+          + '\\ No newline at end of file\n';
+
+        const diffResult = createPatch('testFileName', 'line   \n\ line', 'line\n\line', undefined, undefined, {ignoreWhitespace: false});
+        expect(diffResult).to.equal(expectedResult);
+      });
+
+      it('ignoreWhitespace: true', function() {
+        const expectedResult =
+          'Index: testFileName\n'
+          + '===================================================================\n'
+          + '--- testFileName\n'
+          + '+++ testFileName\n';
+
+        const diffResult = createPatch('testFileName', 'line   \n\ line', 'line\n\line', undefined, undefined, {ignoreWhitespace: true});
+        expect(diffResult).to.equal(expectedResult);
+      });
+    });
   });
 
   describe('#structuredPatch', function() {


### PR DESCRIPTION
The documentation states that createPatch only supports `context`, when in actuality it passes the options on to the diffLines implementation. 

This PR updates the documentation to clarify this and also adds tests to verify this behavior. 

Since these methods are supposed to output a patch, it's arguable that the options doesn't make sense, but I'd argue that the `ignoreWhitespace` at least makes sense since outputting a patch is a pretty normalized way to display a diff and it makes sense to be able to use the existing options for it. 

`newLineIsToken` is a bit weirder when creating "patches". I added docs and tests for that in separate [commit](https://github.com/kpdecker/jsdiff/commit/12eb1729c64ebcd3b9f1d81c289c9502d465bae9) so that it can be reverted if it's something that is not wanted.