### PR TITLE
Fix `exports` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "require": "./lib/index.js"
     },
     "./package.json": "./package.json",
-    "./": "./"
+    "./*": "./*"
   },
   "scripts": {
     "clean": "rm -rf lib/ dist/",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
       "require": "./lib/index.js"
     },
     "./package.json": "./package.json",
+    "./": "./",
     "./*": "./*"
   },
   "scripts": {


### PR DESCRIPTION
Fixes #350

[A solution that postss used](https://github.com/postcss/postcss/commit/92155c73e105a36af5196a75bcc34ada377a711f) seems unnecessary, as I tested, use `"./*": "./*"` works on Node.js 12 too.