### PR TITLE
Add `assumeLineDelimiter` to `applyPatch()` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ npm install diff --save
 
     - `fuzzFactor`: Number of lines that are allowed to differ before rejecting a patch. Defaults to 0.
     - `compareLine(lineNumber, line, operation, patchContent)`: Callback used to compare to given lines to determine if they should be considered equal when patching. Defaults to strict equality but may be overridden to provide fuzzier comparison. Should return false if the lines should be rejected.
+    - `assumeLineDelimiter`: String for line delimiters. When no line delimiter is set in the given patch, this method assumes line delimiter is the string. This option is useful when applying patch from `structuredPatch`.
 
 * `Diff.applyPatches(patch, options)` - applies one or more patches.
 

--- a/src/patch/apply.js
+++ b/src/patch/apply.js
@@ -24,6 +24,7 @@ export function applyPatch(source, uniDiff, options = {}) {
       fuzzFactor = options.fuzzFactor || 0,
       minLine = 0,
       offset = 0,
+      assumeLineDelimiter = options.assumeLineDelimiter,
 
       removeEOFNL,
       addEOFNL;
@@ -89,7 +90,7 @@ export function applyPatch(source, uniDiff, options = {}) {
       let line = hunk.lines[j],
           operation = (line.length > 0 ? line[0] : ' '),
           content = (line.length > 0 ? line.substr(1) : line),
-          delimiter = hunk.linedelimiters[j];
+          delimiter = assumeLineDelimiter || hunk.linedelimiters[j];
 
       if (operation === ' ') {
         toPos++;

--- a/test/patch/apply.js
+++ b/test/patch/apply.js
@@ -721,6 +721,29 @@ describe('patch/apply', function() {
       expect(applyPatch(oldtext, diffed)).to.equal(newtext);
     });
 
+    it('should apply patch without linedelimiter when assumeLineDelimiter option is set', function() {
+      expect(applyPatch(
+          'line1\n'
+          + 'line2\n',
+          {
+            oldFileName: 'file.txt',
+            newFileName: 'file.txt',
+            oldHeader: 'header',
+            newHeader: 'header',
+            hunks: [{
+              oldStart: 1,
+              newStart: 1,
+              oldLines: 2,
+              newLines: 1,
+              lines: ['-line2']
+            }]
+          },
+          {
+            assumeLineDelimiter: '\n'
+          }))
+        .to.equal(
+          'line1\n');
+    });
 
   });
 


### PR DESCRIPTION
Fixes #157
Fixes #228
Fixes #346

Currently return value from `structuredPatch` cannot be applied with `applyPatch`. This is because `linedelimiter` is missing in the hunks of the return value.

This PR adds new option `assumeLineDelimiter` to `applyPatch`. By setting the option, patches can be applied even if the line delimiter information is missing. So `applyPatch` can work with `structuredPatch`.

```js
// Let's say \n is used for newline
const old = ...;
const new = ...;
const patch = structuredPatch('file1', 'file2', old, new, 'header1', header2');
const patched = applyPatch(old, patch, { assumeLineDelimiter: '\n' });
assert.equal(new, patched);
```