### PR TITLE
Default value of line delimiters when a patch is applied (#228)

### DIFF
--- a/src/patch/apply.js
+++ b/src/patch/apply.js
@@ -89,7 +89,7 @@ export function applyPatch(source, uniDiff, options = {}) {
       let line = hunk.lines[j],
           operation = (line.length > 0 ? line[0] : ' '),
           content = (line.length > 0 ? line.substr(1) : line),
-          delimiter = hunk.linedelimiters[j];
+          delimiter = hunk.linedelimiters && hunk.linedelimiters[j] || '\n';
 
       if (operation === ' ') {
         toPos++;

--- a/test/patch/apply.js
+++ b/test/patch/apply.js
@@ -1,6 +1,7 @@
 import {applyPatch, applyPatches} from '../../lib/patch/apply';
 import {parsePatch} from '../../lib/patch/parse';
 import {createPatch} from '../../lib/patch/create';
+import {structuredPatch} from '../../lib/patch/create';
 
 import {expect} from 'chai';
 
@@ -721,7 +722,20 @@ describe('patch/apply', function() {
       expect(applyPatch(oldtext, diffed)).to.equal(newtext);
     });
 
+    it('should accept structured patches', function() {
+      const oldContent = [
+        'line1',
+        'line2',
+        ''
+      ].join('\n');
+      const newContent = [
+        'line1',
+        'line02'
+      ].join('\n');
+      const patch = structuredPatch('test.txt', 'test.txt', oldContent, newContent);
 
+      expect(applyPatch(oldContent, patch)).to.equal(newContent);
+    });
   });
 
   describe('#applyPatches', function() {


### PR DESCRIPTION
Fixes #228

Since a structured patch does not define its line delimiters (#157), this change is needed to prevent an error when the returned value of `structuredPatch` is used in `applyPatch`. The current API does not change:

```js
const oldContent = 'ANYTHING';
const newContent = 'SOMETHING';
const patch = structuredPatch('test.txt', 'test.txt', oldContent, newContent);

expect(applyPatch(oldContent, patch)).to.equal(newContent);
```
