### PR TITLE
[fix] str.split can not handle surrogate pair, replaced with Array.from

### DIFF
--- a/src/diff/base.js
+++ b/src/diff/base.js
@@ -167,7 +167,7 @@ Diff.prototype = {
     return value;
   },
   tokenize(value) {
-    return value.split('');
+    return Array.from(value);
   },
   join(chars) {
     return chars.join('');


### PR DESCRIPTION
example
```
> Array.from("\n𝐀")
[ '\n', '𝐀' ]
```
```
> "\n𝐀".split('')
[ '\n', '\ud835', '\udc00' ]
```