### PR TITLE
Fix assorted trivial capitalisation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://secure.travis-ci.org/kpdecker/jsdiff.svg)](http://travis-ci.org/kpdecker/jsdiff)
 [![Sauce Test Status](https://saucelabs.com/buildstatus/jsdiff)](https://saucelabs.com/u/jsdiff)
 
-A javascript text differencing implementation.
+A JavaScript text differencing implementation.
 
 Based on the algorithm proposed in
 ["An O(ND) Difference Algorithm and its Variations" (Myers, 1986)](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.4.6927).

--- a/components/component.json
+++ b/components/component.json
@@ -1,7 +1,7 @@
 {
   "name": "jsdiff",
   "repo": "kpdecker/jsdiff",
-  "description": "A javascript text diff implementation.",
+  "description": "A JavaScript text diff implementation.",
   "keywords": [
     "diff",
     "text"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diff",
   "version": "5.0.0",
-  "description": "A javascript text diff implementation.",
+  "description": "A JavaScript text diff implementation.",
   "keywords": [
     "diff",
     "jsdiff",

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 /*
  * Text diff implementation.
  *
- * This library supports the following APIS:
+ * This library supports the following APIs:
  * JsDiff.diffChars: Character by character diff
  * JsDiff.diffWords: Word (as defined by \b regex) diff which ignores whitespace
  * JsDiff.diffLines: Line based diff


### PR DESCRIPTION
Nothing of consequence, here - just fixing some miscapitalised words in prose that I noticed while working on more important things.