### PR TITLE
yarn eslint . --fix

### DIFF
--- a/examples/node_example.js
+++ b/examples/node_example.js
@@ -1,15 +1,15 @@
-require('colors')
-var Diff = require('../');
+require('colors');
+let Diff = require('../');
 
-var one = 'beep boop';
-var other = 'beep boob blah';
+let one = 'beep boop';
+let other = 'beep boob blah';
 
-var diff = Diff.diffChars(one, other);
+let diff = Diff.diffChars(one, other);
 
-diff.forEach(function(part){
+diff.forEach(function(part) {
   // green for additions, red for deletions
   // grey for common parts
-  var color = part.added ? 'green' :
+  let color = part.added ? 'green' :
     part.removed ? 'red' : 'grey';
   process.stderr.write(part.value[color]);
 });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -62,6 +62,6 @@ module.exports = function(config) {
     autoWatch: true,
     singleRun: false,
 
-    browsers: ['HeadlessChrome'],
+    browsers: ['HeadlessChrome']
   });
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,13 +16,13 @@ export default [
         file: pkg.module
       }, {
         format: 'esm',
-        file: pkg['exports']['.'].import
+        file: pkg.exports['.']['import']
       }
     ],
     plugins: [
       babel({
         babelrc: false,
-        presets: [['@babel/preset-env', { targets: {ie: '11'}, modules: false }]],
+        presets: [['@babel/preset-env', { targets: {ie: '11'}, modules: false }]]
       })
     ]
   }

--- a/tasks/version.js
+++ b/tasks/version.js
@@ -1,8 +1,8 @@
-var semver = require('semver');
+let semver = require('semver');
 
 module.exports = function(grunt) {
   grunt.registerTask('version', 'Updates the current release version', function() {
-    var done = this.async(),
+    let done = this.async(),
         pkg = grunt.config('pkg'),
         version = grunt.option('ver');
 


### PR DESCRIPTION
We have a .eslintrc, but we don't seem to be respecting it; `yarn eslint .` gets grumpy about lots of things. This fixes the autofixable ones, and in the process:
* Closes https://github.com/kpdecker/jsdiff/pull/405
* Closes https://github.com/kpdecker/jsdiff/pull/406
* Closes https://github.com/kpdecker/jsdiff/pull/407

Something is broken with our eslint config; `yarn eslint .` and `yarn grunt eslint` give radically different results, perhaps suggesting they're using different rule sets? I'll make an issue about that.