### PR TITLE
Update package.json version to 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diff",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "A JavaScript text diff implementation.",
   "keywords": [
     "diff",


### PR DESCRIPTION
As @paultinker notes in https://github.com/kpdecker/jsdiff/issues/413, version 5.1.0 of jsdiff was released to npm last year, but the package.json in the repo still says we're on 5.0.0. Let's update the repo!