### PR TITLE
Flip core algorithm so everything is no longer the mirror image of Myers's paper

### DIFF
--- a/src/diff/base.js
+++ b/src/diff/base.js
@@ -69,7 +69,7 @@ Diff.prototype = {
         }
 
         // Select the diagonal that we want to branch from. We select the prior
-        // path whose position in the new string is the farthest from the origin
+        // path whose position in the old string is the farthest from the origin
         // and does not pass the bounds of the diff graph
         // TODO: Remove the `+ 1` here to make behavior match Myers algorithm
         //       and prefer to order removals before insertions.

--- a/src/diff/base.js
+++ b/src/diff/base.js
@@ -34,11 +34,11 @@ Diff.prototype = {
       maxEditLength = Math.min(maxEditLength, options.maxEditLength);
     }
 
-    let bestPath = [{ newPos: -1, lastComponent: undefined }];
+    let bestPath = [{ oldPos: -1, lastComponent: undefined }];
 
     // Seed editLength = 0, i.e. the content starts with the same values
-    let oldPos = this.extractCommon(bestPath[0], newString, oldString, 0);
-    if (bestPath[0].newPos + 1 >= newLen && oldPos + 1 >= oldLen) {
+    let newPos = this.extractCommon(bestPath[0], newString, oldString, 0);
+    if (bestPath[0].oldPos + 1 >= oldLen && newPos + 1 >= newLen) {
       // Identity per the equality and tokenizer
       return done([{value: this.join(newString), count: newString.length}]);
     }
@@ -47,16 +47,21 @@ Diff.prototype = {
     function execEditLength() {
       for (let diagonalPath = -1 * editLength; diagonalPath <= editLength; diagonalPath += 2) {
         let basePath;
-        let addPath = bestPath[diagonalPath - 1],
-            removePath = bestPath[diagonalPath + 1],
-            oldPos = (removePath ? removePath.newPos : 0) - diagonalPath;
-        if (addPath) {
+        let removePath = bestPath[diagonalPath - 1],
+            addPath = bestPath[diagonalPath + 1];
+        if (removePath) {
           // No one else is going to attempt to use this value, clear it
           bestPath[diagonalPath - 1] = undefined;
         }
 
-        let canAdd = addPath && addPath.newPos + 1 < newLen,
-            canRemove = removePath && 0 <= oldPos && oldPos < oldLen;
+        let canAdd = false;
+        if (addPath) {
+          // what newPos will be after we do an insertion:
+          const addPathNewPos = addPath.oldPos - diagonalPath;
+          canAdd = addPath && 0 <= addPathNewPos && addPathNewPos < newLen;
+        }
+
+        let canRemove = removePath && removePath.oldPos + 1 < oldLen;
         if (!canAdd && !canRemove) {
           // If this path is a terminal then prune
           bestPath[diagonalPath] = undefined;
@@ -66,16 +71,18 @@ Diff.prototype = {
         // Select the diagonal that we want to branch from. We select the prior
         // path whose position in the new string is the farthest from the origin
         // and does not pass the bounds of the diff graph
-        if (!canAdd || (canRemove && addPath.newPos < removePath.newPos)) {
-          basePath = self.addToPath(removePath, undefined, true, 0);
+        // TODO: Remove the `+ 1` here to make behavior match Myers algorithm
+        //       and prefer to order removals before insertions.
+        if (!canRemove || (canAdd && removePath.oldPos + 1 < addPath.oldPos)) {
+          basePath = self.addToPath(addPath, true, undefined, 0);
         } else {
-          basePath = self.addToPath(addPath, true, undefined, 1);
+          basePath = self.addToPath(removePath, undefined, true, 1);
         }
 
-        oldPos = self.extractCommon(basePath, newString, oldString, diagonalPath);
+        newPos = self.extractCommon(basePath, newString, oldString, diagonalPath);
 
         // If we have hit the end of both strings, then we are done
-        if (basePath.newPos + 1 >= newLen && oldPos + 1 >= oldLen) {
+        if (basePath.oldPos + 1 >= oldLen && newPos + 1 >= newLen) {
           return done(buildValues(self, basePath.lastComponent, newString, oldString, self.useLongestToken));
         } else {
           // Otherwise track this path as a potential candidate and continue.
@@ -112,16 +119,16 @@ Diff.prototype = {
     }
   },
 
-  addToPath(path, added, removed, newPosInc) {
+  addToPath(path, added, removed, oldPosInc) {
     let last = path.lastComponent;
     if (last && last.added === added && last.removed === removed) {
       return {
-        newPos: path.newPos + newPosInc,
+        oldPos: path.oldPos + oldPosInc,
         lastComponent: {count: last.count + 1, added: added, removed: removed, previousComponent: last.previousComponent }
       };
     } else {
       return {
-        newPos: path.newPos + newPosInc,
+        oldPos: path.oldPos + oldPosInc,
         lastComponent: {count: 1, added: added, removed: removed, previousComponent: last }
       };
     }
@@ -129,8 +136,8 @@ Diff.prototype = {
   extractCommon(basePath, newString, oldString, diagonalPath) {
     let newLen = newString.length,
         oldLen = oldString.length,
-        newPos = basePath.newPos,
-        oldPos = newPos - diagonalPath,
+        oldPos = basePath.oldPos,
+        newPos = oldPos - diagonalPath,
 
         commonCount = 0;
     while (newPos + 1 < newLen && oldPos + 1 < oldLen && this.equals(newString[newPos + 1], oldString[oldPos + 1])) {
@@ -143,8 +150,8 @@ Diff.prototype = {
       basePath.lastComponent = {count: commonCount, previousComponent: basePath.lastComponent};
     }
 
-    basePath.newPos = newPos;
-    return oldPos;
+    basePath.oldPos = oldPos;
+    return newPos;
   },
 
   equals(left, right) {


### PR DESCRIPTION
Until now, jsdiff's entire implementation has been kind of symmetrically flipped from the algorithm described in the Myers paper. In Myers' paper, each column in the edit graph corresponds to a character in the OLD text (and hence horizontal movements correspond to deletions), while each ROW corresponds to a character in the NEW text (and hence vertical movements correspond to insertions). See page 4:

> ... each horizontal edge to point (x,y) corresponds to the delete command ‘‘x D’’; and a sequence of
vertical edges from (x,y) to (x,z) corresponds to the insert command ...

The numbers of diagonals, meanwhile, are such that a larger diagonal number corresponds to having a higher *x* - i.e. having done more *deletions*:

> Number the diagonals in the grid of edit graph vertices so that diagonal k consists of the points (x,y) for which
x − y = k

Note that this is the opposite of how diagonals are numbered in jsdiff:

```
addPath = bestPath[diagonalPath - 1]
removePath = bestPath[diagonalPath + 1],
```

The algorithm on page 6 shows us recording only the greatest *x* coordinate reached on each diagonal in array V, and shows us choosing whether to reach a diagonal via a vertical or horizontal move as follows:

```
If k = −D or k ≠ D and V[k − 1] < V[k + 1] Then
    x ← V[k + 1]
Else
    x ← V[k − 1]+1
```

x remaining the same (the top case) corresponds to a vertical move, i.e. an insertion. So the logic here says to do an insertion if the path on the more-deletion-heavy side of our target diagonal has made it further through the old string. This means we break ties by preferring to add an insertion on the end of a path that has previously done more deletions rather than adding a deletion on the end of a path which has previously done more insertions.

jsdiff does the mirror image of all of this. Its `diagonalPath` numbers go up as you do *insertions*, not deletions. In `bestPath` it stores objects that have a `newPos` property, corresponding to the *y* coordinate on a Myers edit graph, not the *x*. And it breaks ties in favour of doing a deletion, not an insertion.

This makes jsdiff's diffs differ from the diffs of more popular/canonical tools like the Unix `diff` command, which break ties in favour of doing insertions (i.e. in favour of putting deletions earlier). It also makes it confusing to compare this library to other Myers diff implementations or to apply optimizations suggested in Myers's paper (or elsewhere).

This PR rewrites the algo to better match the paper (though it introduces a hack, noted with a TODO, to preserve the incorrect tiebreak behaviour for now; fixing that is a breaking change and so will go out in a later release).