### PR TITLE
Add test showing patch from bug #177 is handled correctly now

### DIFF
--- a/test/patch/apply.js
+++ b/test/patch/apply.js
@@ -525,6 +525,7 @@ describe('patch/apply', function() {
           + ' line5\n'))
         .to.equal(false);
     });
+
     it('should succeed within fuzz factor', function() {
       expect(applyPatch(
           'line2\n'

--- a/test/patch/apply.js
+++ b/test/patch/apply.js
@@ -737,6 +737,24 @@ describe('patch/apply', function() {
 
       expect(applyPatch(oldContent, patch)).to.equal(newContent);
     });
+
+    // Regression test based on bug https://github.com/kpdecker/jsdiff/issues/177
+    it('should correctly apply a patch that truncates an entire file', function() {
+      const patch = parsePatch(
+        '===================================================================\n'
+        + '--- index.js\n'
+        + '+++ index.js\n'
+        + '@@ -1,3 +1,0 @@\n'
+        + '-this\n'
+        + '-\n'
+        + '-tos\n'
+        + '\\ No newline at end of file\n'
+      );
+      const fileContents = 'this\n\ntos';
+
+      expect(applyPatch(fileContents, patch))
+        .to.equal('');
+    });
   });
 
   describe('#applyPatches', function() {


### PR DESCRIPTION
Over at #177, @dolftax reported a particular example of a patch that `applyPatch` handled incorrectly. However, this test seems to indicate that we no longer apply at least that particular patch incorrectly. Possibly the fix to https://github.com/kpdecker/jsdiff/issues/189 also fixed #177?

Resolves #177.