### PR TITLE
Consistently capitalize "jsdiff" in all-lowercase in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you notice any problems, please report them to the GitHub issue tracker at
 
 ## Releasing
 
-JsDiff utilizes the [release yeoman generator][generator-release] to perform most release tasks.
+jsdiff utilizes the [release yeoman generator][generator-release] to perform most release tasks.
 
 A full release may be completed with the following:
 


### PR DESCRIPTION
Previously we did this in the title of the README but then used a different casing in CONTRIBUTING.md, and I was unsure which to use when adding further mentions of the library's name. This change brings consistency.