### PR TITLE
Add function glyphDiff for emoji and higher UTF8 character support

### DIFF
--- a/src/diff/glyph.js
+++ b/src/diff/glyph.js
@@ -1,0 +1,15 @@
+import Diff from './base';
+
+export const glyphDiff = new Diff();
+glyphDiff.tokenize = function(value) {
+  return [...value];
+};
+glyphDiff.join = function(value) {
+  return value.join('');
+};
+glyphDiff.removeEmpty = function(value) {
+  return value.filter((str) => str !== '');
+};
+export function diffGlyph(oldStr, newStr, options) {
+  return glyphDiff.diff(oldStr, newStr, options);
+}

--- a/test/diff/glyph.js
+++ b/test/diff/glyph.js
@@ -1,0 +1,23 @@
+import {diffGlyph} from '../../lib/diff/glyph';
+import {convertChangesToXML} from '../../lib/convert/xml';
+
+import {expect} from 'chai';
+
+describe('diff/glyph', function() {
+  describe('#diffGlyph', function() {
+    describe('extended unicode characters', function() {
+      it('are treated as single characters when inserted', function() {
+        const diffResult = diffGlyph('New 🐴.', 'New 🐴🐴MoreData.', {removeEmpty: true});
+        expect(convertChangesToXML(diffResult)).to.equal('New 🐴<ins>🐴MoreData</ins>.');
+      });
+      it('are treated as single characters when deleted', function() {
+        const diffResult = diffGlyph('New 🐴🐴.', 'New 🐴.', {removeEmpty: true});
+        expect(convertChangesToXML(diffResult)).to.equal('New 🐴<del>🐴</del>.');
+      });
+      it('are treated as single characters when equal', function() {
+        const diffResult = diffGlyph('New 🐴.', 'New 🐴.', {removeEmpty: true});
+        expect(convertChangesToXML(diffResult)).to.equal('New 🐴.');
+      });
+    });
+  });
+});


### PR DESCRIPTION
the character diff currently does not handle high utf8 like emoji as their length is not calculated correctly. instead of breaking the old characterDiff method we now have a glyphDiff method for this purpose as it may perform worse than the existing method.
this PR extends the test suite and passes with 100% coverage