### PR TITLE
Migrate to DABH's fork of colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.5",
     "chai": "^4.2.0",
-    "colors": "^1.3.3",
+    "@colors/colors": "^1.3.3",
     "eslint": "^5.12.0",
     "grunt": "^1.0.3",
     "grunt-babel": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,6 +945,11 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
+"@colors/colors@^1.3.3":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.6.0.tgz#ec6cd237440700bc23ca23087f513c75508958b0"
+  integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
+
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
@@ -2371,7 +2376,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colors@1.4.0, colors@^1.3.3:
+colors@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
Resolves https://github.com/kpdecker/jsdiff/issues/337

As I understand it, the original maintainer of the `colors` package, Marak, previously sabotaged it for a laundry list of political/ideological reasons, involving Aaron Schwartz, the Ukraine war, and big corporations using his code. npm removed the malicious version against the old maintainer's will, but one still has to wonder if he might one day sabotage his packages again. Anything by him is kinda suspect, now.

Someone else called DABH took over maintainership after the sabotage. Let's point at the npm package _he_ controls, just to be sure that bumping our dev dependencies in future won't install malware.

The (tiny, trivial) example script that uses `colors` still seems to work after this:

![image](https://github.com/kpdecker/jsdiff/assets/2358339/ba7823eb-d2cf-4f96-99a9-ab45d341ab8e)
