### PR TITLE
Replace broken link to Myers's paper in the README with a working one

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A JavaScript text differencing implementation. Try it out in the **[online demo](https://kpdecker.github.io/jsdiff)**.
 
 Based on the algorithm proposed in
-["An O(ND) Difference Algorithm and its Variations" (Myers, 1986)](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.4.6927).
+["An O(ND) Difference Algorithm and its Variations" (Myers, 1986)](http://www.xmailserver.org/diff2.pdf).
 
 ## Installation
 ```bash


### PR DESCRIPTION
(Clicking the VIEW PDF button at https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.4.6927 just takes me to an error page saying `{"message":"Token is required"}`.)