### PR TITLE
Modify node_example.js to support showing added/deleted spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,10 @@ const diff = Diff.diffChars(one, other);
 
 diff.forEach((part) => {
   // green for additions, red for deletions
-  // grey for common parts
-  const color = part.added ? 'green' :
-    part.removed ? 'red' : 'grey';
-  process.stderr.write(part.value[color]);
+  let text = part.added ? part.value.bgGreen :
+             part.removed ? part.value.bgRed :
+                            part.value;
+  process.stderr.write(text);
 });
 
 console.log();

--- a/examples/node_example.js
+++ b/examples/node_example.js
@@ -8,10 +8,10 @@ let diff = Diff.diffChars(one, other);
 
 diff.forEach(function(part) {
   // green for additions, red for deletions
-  // grey for common parts
-  let color = part.added ? 'green' :
-    part.removed ? 'red' : 'grey';
-  process.stderr.write(part.value[color]);
+  let text = part.added ? part.value.bgGreen :
+             part.removed ? part.value.bgRed :
+                            part.value;
+  process.stderr.write(text);
 });
 
 console.log();


### PR DESCRIPTION
Resolves https://github.com/kpdecker/jsdiff/issues/414

As noted there, we can't color *both* the background and text in green/red of different shades, like the HTML example does, because terminals only support a limited number of shades and "red" text on "bright red" background is almost completely illegible on some terminals. Therefore this PR swaps us from coloring ONLY the text to instead coloring ONLY the background. This should still clearly show what letters are added/deleted, but now also makes added/deleted spaces visible, which they weren't before.

Here's a screenshot showing the behaviour change:

![image](https://github.com/kpdecker/jsdiff/assets/2358339/058c5596-8660-4039-ba64-f26c0cde7870)
