### PR TITLE
Sort out behaviour of newlineIsToken and ignoreWhitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,10 @@ Broadly, jsdiff's diff functions all take an old text and a new text and perform
 * `Diff.diffLines(oldStr, newStr[, options])` - diffs two blocks of text, treating each line as a token.
 
     Options
-    * `ignoreWhitespace`: `true` to strip all leading and trailing whitespace characters from each line before performing the diff. Defaults to `false`.
+    * `ignoreWhitespace`: `true` to ignore leading and trailing whitespace characters when checking if two lines are equal. Defaults to `false`.
     * `stripTrailingCr`: `true` to remove all trailing CR (`\r`) characters before performing the diff. Defaults to `false`.
       This helps to get a useful diff when diffing UNIX text files against Windows text files.
     * `newlineIsToken`: `true` to treat the newline character at the end of each line as its own token. This allows for changes to the newline structure to occur independently of the line content and to be treated as such. In general this is the more human friendly form of `diffLines`; the default behavior with this option turned off is better suited for patches and other computer friendly output. Defaults to `false`.
-
-    Returns a list of [change objects](#change-objects).
-
-* `Diff.diffTrimmedLines(oldStr, newStr[, options])` - diffs two blocks of text, comparing line by line, after stripping leading and trailing whitespace. Equivalent to calling `diffLines` with `ignoreWhitespace: true`.
-
-    Options
-    * `stripTrailingCr`: Same as in `diffLines`. Defaults to `false`.
-    * `newlineIsToken`: Same as in `diffLines`. Defaults to `false`.
 
     Returns a list of [change objects](#change-objects).
 

--- a/src/diff/line.js
+++ b/src/diff/line.js
@@ -23,9 +23,6 @@ lineDiff.tokenize = function(value) {
     if (i % 2 && !this.options.newlineIsToken) {
       retLines[retLines.length - 1] += line;
     } else {
-      if (this.options.ignoreWhitespace) {
-        line = line.trim();
-      }
       retLines.push(line);
     }
   }
@@ -33,7 +30,33 @@ lineDiff.tokenize = function(value) {
   return retLines;
 };
 
+lineDiff.equals = function(left, right) {
+  // If we're ignoring whitespace, we need to normalise lines by stripping
+  // whitespace before checking equality. (This has an annoying interaction
+  // with newlineIsToken that requires special handling: if newlines get their
+  // own token, then we DON'T want to trim the *newlines* tokens down to empty
+  // strings, since this would cause us to treat whitespace-only line content
+  // as equal to a separator between lines, which would be weird and
+  // inconsistent with the documented behavior of the options.)
+  if (this.options.ignoreWhitespace) {
+    if (!this.options.newlineIsToken || !left.includes("\n")) {
+      left = left.trim();
+    }
+    if (!this.options.newlineIsToken || !right.includes("\n")) {
+      right = right.trim();
+    }
+  }
+  return Diff.equals(left, right);
+}
+
 export function diffLines(oldStr, newStr, callback) { return lineDiff.diff(oldStr, newStr, callback); }
+
+// Kept for backwards compatibility. This is a rather arbitrary wrapper method
+// that just calls `diffLines` with `ignoreWhitespace: true`. It's confusing to
+// have two ways to do exactly the same thing in the API, so we no longer
+// document this one (library users should explicitly use `diffLines` with
+// `ignoreWhitespace: true` instead) but we keep it around to maintain
+// compatibility with code that used old versions.
 export function diffTrimmedLines(oldStr, newStr, callback) {
   let options = generateOptions(callback, {ignoreWhitespace: true});
   return lineDiff.diff(oldStr, newStr, options);


### PR DESCRIPTION
Three fixes here:

* `ignoreWhitespace` now behaves the same as other `ignoreXxx` methods - i.e. changes how tokens are compared for equality but does NOT affect the `value`s that show up in the returned change objects. Resolves https://github.com/kpdecker/jsdiff/pull/219.
* Fix the incompatibility between `newlineIsToken` and `ignoreWhitespace`. Resolves https://github.com/kpdecker/jsdiff/issues/472, albeit not quite in the way I'd originally intended.
* I've undocumented `diffTrimmedLines`. I don't see a reason to have two ways (`diffTrimmedLines` & `ignoreWhitespace`) to do exactly the same thing, so I've purged one from the *documented* API. (I'll still keep the method itself around just for backwards compat, though.)

For me to do before merging:
- [ ] Sanity check this works at all
- [ ] Add release notes. Remember to call out the deprecation of `diffTrimmedLines`.
- [ ] Take another look at https://github.com/kpdecker/jsdiff/pull/219. (I didn't read the diff there before doing my own work on this - I'd actually forgotten @Mingun had actually put up a *PR* about this and not just an issue.)
- [ ] Update the failing tests
- [ ] Add a new test confirming compatibility between `newlineIsToken` and `ignoreWhitespace`.