### PR TITLE
Support `Object.create(null)` in JSON diffing

### DIFF
--- a/src/diff/json.js
+++ b/src/diff/json.js
@@ -1,8 +1,9 @@
 import Diff from './base';
 import {lineDiff} from './line';
 
-const objectPrototypeToString = Object.prototype.toString;
-
+const objectPrototype = Object.prototype;
+const objectPrototypeToString = objectPrototype.toString;
+const objectPrototypeHasOwnProperty = objectPrototype.hasOwnProperty;
 
 export const jsonDiff = new Diff();
 // Discriminate between two lines of pretty-printed, serialized JSON where one of them has a
@@ -65,7 +66,7 @@ export function canonicalize(obj, stack, replacementStack, replacer, key) {
         key;
     for (key in obj) {
       /* istanbul ignore else */
-      if (obj.hasOwnProperty(key)) {
+      if (objectPrototypeHasOwnProperty.call(obj, key)) {
         sortedKeys.push(key);
       }
     }

--- a/src/diff/json.js
+++ b/src/diff/json.js
@@ -1,10 +1,6 @@
 import Diff from './base';
 import {lineDiff} from './line';
 
-const objectPrototype = Object.prototype;
-const objectPrototypeToString = objectPrototype.toString;
-const objectPrototypeHasOwnProperty = objectPrototype.hasOwnProperty;
-
 export const jsonDiff = new Diff();
 // Discriminate between two lines of pretty-printed, serialized JSON where one of them has a
 // dangling comma and the other doesn't. Turns out including the dangling comma yields the nicest output:
@@ -42,7 +38,7 @@ export function canonicalize(obj, stack, replacementStack, replacer, key) {
 
   let canonicalizedObj;
 
-  if ('[object Array]' === objectPrototypeToString.call(obj)) {
+  if ('[object Array]' === Object.prototype.toString.call(obj)) {
     stack.push(obj);
     canonicalizedObj = new Array(obj.length);
     replacementStack.push(canonicalizedObj);
@@ -66,7 +62,7 @@ export function canonicalize(obj, stack, replacementStack, replacer, key) {
         key;
     for (key in obj) {
       /* istanbul ignore else */
-      if (objectPrototypeHasOwnProperty.call(obj, key)) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
         sortedKeys.push(key);
       }
     }

--- a/test/diff/json.js
+++ b/test/diff/json.js
@@ -182,6 +182,22 @@ describe('diff/json', function() {
         { count: 1, value: '}', removed: false, added: false }
       ]);
     });
+
+    it("doesn't throw on Object.create(null)", function() {
+      let diff;
+      expect(function() {
+        diff = diffJson(
+          Object.assign(Object.create(null), {a: 123}),
+          {b: 456}
+        );
+      }).not.to['throw']();
+      expect(diff).to.eql([
+        { count: 1, value: '{\n', removed: false, added: false },
+        { count: 1, value: '  \"a\": 123\n', removed: true, added: false },
+        { count: 1, value: '  \"b\": 456\n', removed: false, added: true },
+        { count: 1, value: '}', removed: false, added: false }
+      ]);
+    });
   });
 });
 


### PR DESCRIPTION
Addresses https://github.com/kpdecker/jsdiff/issues/492

I was recently trying to use `diff` to compare output from a library that makes use of `Object.create(null)`.  This seems valid (if not encouraged) in some situations, but `diff` was throwing as the `typeof` this is `'object'` and it is `!== null` but `obj.hasOwnProperty` does not exist.

Instead, use `Object.prototype.hasOwnProperty.call(obj, key)` similar to the way that `Object.prototyope.toString` is used elsewhere in this library.