### PR TITLE
Fix handling of EOF in createPatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ Broadly, jsdiff's diff functions all take an old text and a new text and perform
       - `context` describes how many lines of context should be included. You can set this to `Number.MAX_SAFE_INTEGER` or `Infinity` to include the entire file content in one hunk.
       - `ignoreWhitespace`: Same as in `diffLines`. Defaults to `false`.
       - `stripTrailingCr`: Same as in `diffLines`. Defaults to `false`.
-      - `newlineIsToken`: Same as in `diffLines`. Defaults to `false`.
 
 * `Diff.createPatch(fileName, oldStr, newStr[, oldHeader[, newHeader[, options]]])` - creates a unified diff patch.
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -32,6 +32,8 @@
   * The `fuzzFactor` now indicates the maximum [*Levenshtein* distance](https://en.wikipedia.org/wiki/Levenshtein_distance) that there can be between the context shown in a hunk and the actual file content at a location where we try to apply the hunk. (Previously, it represented a maximum [*Hamming* distance](https://en.wikipedia.org/wiki/Hamming_distance), meaning that a single insertion or deletion in the source file could stop a hunk from applying even with a high `fuzzFactor`.)
   * A hunk containing a deletion can now only be applied in a context where the line to be deleted actually appears verbatim. (Previously, as long as enough context lines in the hunk matched, `applyPatch` would apply the hunk anyway and delete a completely different line.)
   * The context line immediately before and immediately after an insertion must match exactly between the hunk and the file for a hunk to apply. (Previously this was not required.)
+- [#535](https://github.com/kpdecker/jsdiff/pull/535) **A bug in patch generation functions is now fixed** that would sometimes previously cause `\ No newline at end of file` to appear in the wrong place in the generated patch, resulting in the patch being invalid.
+- [#535](https://github.com/kpdecker/jsdiff/pull/535) **Passing `newlineIsToken: true` to *patch*-generation functions is no longer allowed.** (Passing it to `diffLines` is still supported - it's only functions like `createPatch` where passing `newlineIsToken` is now an error.) Allowing it to be passed never really made sense, since in cases where the option had any effect on the output at all, the effect tended to be causing a garbled patch to be created that couldn't actually be applied to the source file.
 
 ## v5.2.0
 

--- a/src/patch/create.js
+++ b/src/patch/create.js
@@ -10,6 +10,9 @@ export function structuredPatch(oldFileName, newFileName, oldStr, newStr, oldHea
   if (typeof options.context === 'undefined') {
     options.context = 4;
   }
+  if (options.newlineIsToken) {
+    throw new Error('newlineIsToken may not be used with patch-generation functions, only with diffing functions');
+  }
 
   if (!options.callback) {
     return diffLinesResultToPatch(diffLines(oldStr, newStr, options));

--- a/src/patch/create.js
+++ b/src/patch/create.js
@@ -207,9 +207,6 @@ export function createPatch(fileName, oldStr, newStr, oldHeader, newHeader, opti
  * Split `text` into an array of lines, including the trailing newline character (where present)
  */
 function splitLines(text) {
-  if (!text) {
-    return [];
-  }
   const hasTrailingNl = text.endsWith('\n');
   const result = text.split('\n').map(line => line + '\n');
   if (hasTrailingNl) {

--- a/test/patch/create.js
+++ b/test/patch/create.js
@@ -702,46 +702,13 @@ describe('patch/create', function() {
     });
 
     describe('newlineIsToken', function() {
-      it('newlineIsToken: false', function() {
-        const expectedResult =
-          'Index: testFileName\n'
-          + '===================================================================\n'
-          + '--- testFileName\n'
-          + '+++ testFileName\n'
-          + '@@ -1,2 +1,2 @@\n'
-
-          // Diff is shown as entire row, even though text is unchanged
-          + '-line\n'
-          + '+line\r\n'
-
-          + ' line\n'
-          + '\\ No newline at end of file\n';
-
-        const diffResult = createPatch('testFileName', 'line\nline', 'line\r\nline', undefined, undefined, {newlineIsToken: false});
-        expect(diffResult).to.equal(expectedResult);
-      });
-
-      it('newlineIsToken: true', function() {
-        const expectedResult =
-          'Index: testFileName\n'
-          + '===================================================================\n'
-          + '--- testFileName\n'
-          + '+++ testFileName\n'
-          + '@@ -1,3 +1,3 @@\n'
-          + ' line\n'
-
-          // Newline change is shown as a single diff
-          + '-\n'
-          + '+\r\n'
-
-          + ' line\n'
-          + '\\ No newline at end of file\n';
-
-        const diffResult = createPatch('testFileName', 'line\nline', 'line\r\nline', undefined, undefined, {newlineIsToken: true});
-        expect(diffResult).to.equal(expectedResult);
+      // See https://github.com/kpdecker/jsdiff/pull/345#issuecomment-2255886105
+      it("isn't allowed any more, since the patches produced were nonsense", function() {
+        expect(() => {
+          createPatch('testFileName', 'line\nline', 'line\r\nline', undefined, undefined, {newlineIsToken: true});
+        }).to['throw']('newlineIsToken may not be used with patch-generation functions, only with diffing functions');
       });
     });
-
 
     it('takes an optional callback option', function(done) {
       createPatch(

--- a/test/patch/create.js
+++ b/test/patch/create.js
@@ -120,7 +120,8 @@ describe('patch/create', function() {
       );
 
       expect(diff).to.equal(
-        '===================================================================\n'
+        'Index: a.txt\n'
+        + '===================================================================\n'
         + '--- a.txt\n'
         + '+++ a.txt\n'
         + '@@ -1,3 +1,7 @@\n'
@@ -134,7 +135,7 @@ describe('patch/create', function() {
         + '+3rd line.\n'
         + '+\n'
         + '+SOMETHING ELSE.\n'
-        + '\\ No newline at end of file'
+        + '\\ No newline at end of file\n'
       );
     });
 

--- a/test/patch/create.js
+++ b/test/patch/create.js
@@ -106,6 +106,38 @@ describe('patch/create', function() {
         + '\\ No newline at end of file\n');
     });
 
+    it('should get the "No newline" position right in the case from https://github.com/kpdecker/jsdiff/issues/531', function() {
+      const oldContent = '1st line.\n2nd line.\n3rd line.';
+      const newContent = 'Z11 thing.\nA New thing.\n2nd line.\nNEW LINE.\n3rd line.\n\nSOMETHING ELSE.';
+
+      const diff = createPatch(
+        'a.txt',
+        oldContent,
+        newContent,
+        undefined,
+        undefined,
+        { context: 3 },
+      );
+
+      expect(diff).to.equal(
+        '===================================================================\n'
+        + '--- a.txt\n'
+        + '+++ a.txt\n'
+        + '@@ -1,3 +1,7 @@\n'
+        + '-1st line.\n'
+        + '+Z11 thing.\n'
+        + '+A New thing.\n'
+        + ' 2nd line.\n'
+        + '-3rd line.\n'
+        + '\\ No newline at end of file\n'
+        + '+NEW LINE.\n'
+        + '+3rd line.\n'
+        + '+\n'
+        + '+SOMETHING ELSE.\n'
+        + '\\ No newline at end of file'
+      );
+    });
+
     it('should output "no newline" at end of file message on context missing nl', function() {
       expect(createPatch('test', 'line11\nline2\nline3\nline4', 'line1\nline2\nline3\nline4', 'header1', 'header2')).to.equal(
         'Index: test\n'


### PR DESCRIPTION
Fixes https://github.com/kpdecker/jsdiff/issues/531.

But also rips out the ability to pass `newlineIsToken` to `createPatch` et al, because my changes here broke the tests (that @oBusk had added in https://github.com/kpdecker/jsdiff/pull/345) for that feature and when I dug into it I realised - like I think @oBusk kinda implies in that PR description - that the whole feature is kinda broken, since it causes line ending changes to get falsely represented as deletions and insertions of entire blank lines in the patch.

(I suspect @Kiougar didn't consider the `newlineIsToken` option specifically back in 2016 when he wrote https://github.com/kpdecker/jsdiff/pull/153, and was probably thinking primarily about options like `ignoreWhitespace` which *do* make sense to pass to patch functions.)