### PR TITLE
Stop using old 'import assertions' syntax that was removed in Node 22

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,5 +1,5 @@
 import babel from 'rollup-plugin-babel';
-import pkg from './package.json' assert { type: 'json' };
+import pkg from './package.json' with { type: 'json' };
 
 export default [
   // browser-friendly UMD build


### PR DESCRIPTION
I haven't tested everything on Node 22 yet, but this should stop at least one way the build is broken in Node 22. Fixes https://github.com/kpdecker/jsdiff/issues/537.