### PR TITLE
Fix reference to no-longer-existent 'rollup.config.js' file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,7 +10,7 @@ Gruntfile.js
 images
 index.html
 karma.conf.js
-rollup.config.js
+rollup.config.mjs
 src
 tasks
 test


### PR DESCRIPTION
Should've been done as part of https://github.com/kpdecker/jsdiff/pull/505, but I missed it