### PR TITLE
Fix diffWords treating numbers and underscores as not being word characters

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Future 7.0.0 release
+
+- [#554](https://github.com/kpdecker/jsdiff/pull/554) **`diffWords` treats numbers and underscores as word characters again.** This behaviour was broken in v6.0.0.
+
 ## 6.0.0
 
 This is a release containing many, *many* breaking changes. The objective of this release was to carry out a mass fix, in one go, of all the open bugs and design problems that required breaking changes to fix. A substantial, but exhaustive, changelog is below.

--- a/src/diff/word.js
+++ b/src/diff/word.js
@@ -19,7 +19,7 @@ import { longestCommonPrefix, longestCommonSuffix, replacePrefix, replaceSuffix,
 //  - U+02DC  ˜ &#732;  Small Tilde
 //  - U+02DD  ˝ &#733;  Double Acute Accent
 // Latin Extended Additional, 1E00–1EFF
-const extendedWordChars = 'a-zA-Z\\u{C0}-\\u{FF}\\u{D8}-\\u{F6}\\u{F8}-\\u{2C6}\\u{2C8}-\\u{2D7}\\u{2DE}-\\u{2FF}\\u{1E00}-\\u{1EFF}';
+const extendedWordChars = 'a-zA-Z0-9_\\u{C0}-\\u{FF}\\u{D8}-\\u{F6}\\u{F8}-\\u{2C6}\\u{2C8}-\\u{2D7}\\u{2DE}-\\u{2FF}\\u{1E00}-\\u{1EFF}';
 
 // Each token is one of the following:
 // - A punctuation mark plus the surrounding whitespace

--- a/test/diff/word.js
+++ b/test/diff/word.js
@@ -31,6 +31,34 @@ describe('WordDiff', function() {
         '.'
       ]);
     });
+
+    // Test for bug reported at https://github.com/kpdecker/jsdiff/issues/553
+    it('should treat numbers as part of a word if not separated by whitespace or punctuation', () => {
+      expect(
+        wordDiff.tokenize(
+          'Tea Too, also known as T2, had revenue of 57m AUD in 2012-13.'
+        )
+      ).to.deep.equal([
+        'Tea ',
+        ' Too',
+        ', ',
+        ' also ',
+        ' known ',
+        ' as ',
+        ' T2',
+        ', ',
+        ' had ',
+        ' revenue ',
+        ' of ',
+        ' 57m ',
+        ' AUD ',
+        ' in ',
+        ' 2012',
+        '-',
+        '13',
+        '.'
+      ]);
+    });
   });
 
   describe('#diffWords', function() {


### PR DESCRIPTION
Fixes https://github.com/kpdecker/jsdiff/issues/553 (the original issue, not the orthogonal bug posted in a comment).

The bug was introduced in https://github.com/kpdecker/jsdiff/pull/494. Previously we were splitting into words on [`\b`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Word_boundary_assertion), which per the linked MDN docs considers the following things to be word characters:

> Letters (A–Z, a–z), numbers (0–9), and underscore (_).

Then I swapped to using the `extendedWordChars` regex (previously only used for stitching together some adjacent tokens into single tokens after the original splitting), but didn't ensure it actually contained all the things that `\b` considers to be word characters.

This should fix it!