### PR TITLE
Ensure the result can be scrolled independently from the source

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 	<tr>
 		<td contenteditable="true" id="a">restaurant</td>
 		<td contenteditable="true" id="b">aura</td>
-		<td><pre id="result"></pre></td>
+		<td id="result_wrapper"><pre id="result"></pre></td>
 	</tr>
 </table>
 

--- a/style.css
+++ b/style.css
@@ -47,6 +47,10 @@ ins {
 	text-decoration: none;
 }
 
+#result_wrapper {
+	position: fixed;
+	overflow: scroll;
+}
 #result {
 	white-space: pre-wrap;
 }


### PR DESCRIPTION
When using the patch view, the patch results can be relatively small compared the source text, so it'd be useful if the results could be viewed and scrolled independently of the source.