### PR TITLE
Fix the gh-pages demo for Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
 
 <table>
 	<tr>
-		<td><div contenteditable="true" id="a">restaurant</div></td>
-		<td><div contenteditable="true" id="b">aura</td>
+		<td><textarea id="a">restaurant</textarea></td>
+		<td><textarea id="b">aura</textarea></td>
 		<td><div><pre id="result"></pre></div></td>
 	</tr>
 </table>
@@ -38,7 +38,7 @@ function changed() {
 		// We contort the patch into a similar data structure to that returned by diffChars,
 		// diffWords, etc so that the same rendering code below can work on both.
 		var pastHunkHeader = false;
-		diff = Diff.createTwoFilesPatch('a.txt', 'b.txt', a.textContent, b.textContent)
+		diff = Diff.createTwoFilesPatch('a.txt', 'b.txt', a.value, b.value)
 			.split('\n')
 			.map(function(entry) {
 				const result = {
@@ -57,7 +57,7 @@ function changed() {
 				return result;
 			});
 	} else {
-		diff = Diff[window.diffType](a.textContent, b.textContent);
+		diff = Diff[window.diffType](a.value, b.value);
 	}
 
 	for (var i=0; i < diff.length; i++) {

--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@ body {
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
-html, body, table, tbody, tr, td, td>div {
+html, body, table, tbody, tr, td, textarea, div {
 	height: 100%
 }
 table {
@@ -25,11 +25,11 @@ td {
 	padding: 3px 4px;
 	border: 1px solid transparent;
 }
-td div {
+td div, td textarea {
 	overflow: auto;
 	font: 1em monospace;
-	text-align: left;
-	white-space: pre-wrap;
+	width: 100%;
+	resize: none;
 }
 h1 {
 	display: inline;
@@ -72,14 +72,13 @@ ins {
 	top: .2em;
 }
 
-[contentEditable] {
+textarea {
 	background: #F9F9F9;
 	border-color: #BBB #D9D9D9 #DDD;
 	border-radius: 4px;
-	-webkit-user-modify: read-write-plaintext-only;
 	outline: none;
 }
-[contentEditable]:focus {
+textarea:focus {
 	background: #FFF;
 	border-color: #6699cc;
 	box-shadow: 0 0 4px #2175c9;

--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@ body {
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
-html, body, table, tbody, tr, td, td div {
+html, body, table, tbody, tr, td, td>div {
 	height: 100%
 }
 table {


### PR DESCRIPTION
Two things were broken:

1. Newlines rendered as massive page breaks instead of newlines, because Firefox creates `<div>` elements within the `contenteditable` to represent newlines and our CSS was making them `height: 100%`.
2. We weren't reading the typed content from the editable divs correctly, because you can't just use `textContent` or `innerText` for that - see e.g. https://stackoverflow.com/q/64105609/1709587 and https://stephenhaney.com/2020/get-contenteditable-plaintext-with-correct-linebreaks/

Point 1 is easy to fix, though I worry slightly that some browsers might do really eccentric things (and I don't have a Mac to test Safari). Point 2, there are fixes available (see Stephen Haney's post, or https://stackoverflow.com/a/15349136/1709587) but they're kinda hacky and make me nervous.

Fortunately I don't think we need to use either of those hacks nor do anything clever to fix this, because we can simply replace the `contenteditable` div with a `textarea`. We never needed any functionality more complicated than what a `textarea` provides in the first place!

Fixes https://github.com/kpdecker/jsdiff/issues/575

