### PR TITLE
Tweak eslint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,17 +35,12 @@ export default [
             "no-negated-in-lhs": 2,
             "no-obj-calls": 2,
             "no-regex-spaces": 2,
-            "no-sparse-arrays": 0,
             "no-unreachable": 1, // Optimizer and coverage will handle/highlight this and can be useful for debugging
             "use-isnan": 2,
-            "valid-jsdoc": 0,
             "valid-typeof": 2,
 
             // Best Practices //
             //----------------//
-            "block-scoped-var": 0,
-            complexity: 0,
-            "consistent-return": 0,
             curly: 2,
             "default-case": 1,
 
@@ -53,13 +48,10 @@ export default [
                 allowKeywords: false,
             }],
 
-            eqeqeq: 0,
             "guard-for-in": 1,
             "no-alert": 2,
             "no-caller": 2,
             "no-div-regex": 1,
-            "no-else-return": 0,
-            "no-eq-null": 0,
             "no-eval": 2,
             "no-extend-native": 2,
             "no-extra-bind": 2,
@@ -69,7 +61,6 @@ export default [
             "no-iterator": 2,
             "no-labels": 2,
             "no-lone-blocks": 2,
-            "no-loop-func": 0,
             "no-multi-spaces": 2,
             "no-multi-str": 1,
             "no-native-reassign": 2,
@@ -78,7 +69,6 @@ export default [
             "no-new-wrappers": 2,
             "no-octal": 2,
             "no-octal-escape": 2,
-            "no-param-reassign": 0,
             "no-process-env": 2,
             "no-proto": 2,
             "no-redeclare": 2,
@@ -88,28 +78,18 @@ export default [
             "no-sequences": 2,
             "no-throw-literal": 2,
             "no-unused-expressions": 2,
-            "no-void": 0,
             "no-warning-comments": 1,
             "no-with": 2,
             radix: 2,
-            "vars-on-top": 0,
             "wrap-iife": 2,
-            yoda: 0,
-
-            // Strict //
-            //--------//
-            strict: 0,
 
             // Variables //
             //-----------//
             "no-catch-shadow": 2,
             "no-delete-var": 2,
             "no-label-var": 2,
-            "no-shadow": 0,
-            "no-shadow-restricted-names": 0,
             "no-undef": 2,
             "no-undef-init": 2,
-            "no-undefined": 0,
 
             "no-unused-vars": [2, {
                 vars: "all",
@@ -120,11 +100,9 @@ export default [
 
             // Node.js //
             //---------//
-            "no-mixed-requires": 0, // Others left to environment defaults
 
             // Stylistic //
             //-----------//
-            indent: 0,
             "brace-style": [2, "1tbs", {
                 allowSingleLine: true,
             }],
@@ -139,7 +117,6 @@ export default [
             "comma-style": [2, "last"],
             "consistent-this": [1, "self"],
             "eol-last": 2,
-            "func-names": 0,
             "func-style": [2, "declaration"],
 
             "key-spacing": [2, {
@@ -147,25 +124,15 @@ export default [
                 afterColon: true,
             }],
 
-            "max-nested-callbacks": 0,
             "new-cap": 2,
             "new-parens": 2,
-            "newline-after-var": 0,
             "no-array-constructor": 2,
-            "no-continue": 0,
-            "no-inline-comments": 0,
             "no-lonely-if": 2,
             "no-mixed-spaces-and-tabs": 2,
-            "no-multiple-empty-lines": 0,
             "no-nested-ternary": 1,
             "no-new-object": 2,
             "no-spaced-func": 2,
-            "no-ternary": 0,
             "no-trailing-spaces": 2,
-            "no-underscore-dangle": 0,
-            "one-var": 0,
-            "operator-assignment": 0,
-            "padded-blocks": 0,
 
             "quote-props": [2, "as-needed", {
                 keywords: true,
@@ -179,7 +146,6 @@ export default [
                 after: true,
             }],
 
-            "sort-vars": 0,
             "space-before-blocks": [2, "always"],
 
             "space-before-function-paren": [2, {
@@ -187,7 +153,6 @@ export default [
                 named: "never",
             }],
 
-            "space-in-brackets": 0,
             "space-in-parens": [2, "never"],
             "space-infix-ops": 2,
             "space-unary-ops": 2,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -171,8 +171,6 @@ export default [
         },
         rules: {
             "no-unused-expressions": 0, // Needs disabling to support Chai `.to.be.undefined` etc syntax
-            "no-path-concat": 0,
-            "no-console": 0,
         },
     }
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -205,7 +205,7 @@ export default [
             },
         },
         rules: {
-            "no-unused-expressions": 0, // Disabling for tests, for now.
+            "no-unused-expressions": 0, // Needs disabling to support Chai `.to.be.undefined` etc syntax
             "no-path-concat": 0,
             "no-console": 0,
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,7 +30,6 @@ export default [
             "no-extra-parens": [2, "functions"],
             "no-extra-semi": 2,
             "no-func-assign": 2,
-            "no-inner-declarations": 0, // Stylistic... might consider disallowing in the future
             "no-invalid-regexp": 2,
             "no-irregular-whitespace": 2,
             "no-negated-in-lhs": 2,

--- a/test/diff/array.js
+++ b/test/diff/array.js
@@ -7,7 +7,6 @@ describe('diff/array', function() {
     it('Should diff arrays', function() {
       const a = {a: 0}, b = {b: 1}, c = {c: 2};
       const diffResult = diffArrays([a, b, c], [a, c, b]);
-      console.log(diffResult);
       expect(diffResult).to.deep.equals([
           {count: 1, value: [a], removed: false, added: false},
           {count: 1, value: [b], removed: true, added: false},
@@ -68,7 +67,6 @@ describe('diff/array', function() {
         return left.a === right.a;
       }
       const diffResult = diffArrays([a, b, c], [a, b, d], { comparator: comparator });
-      console.log(diffResult);
       expect(diffResult).to.deep.equals([
           {count: 2, value: [a, b], removed: false, added: false},
           {count: 1, value: [c], removed: true, added: false},

--- a/test/patch/create.js
+++ b/test/patch/create.js
@@ -6,6 +6,7 @@ import {expect} from 'chai';
 
 const VERBOSE = false;
 function log() {
+  // eslint-disable-next-line no-console
   VERBOSE && console.log.apply(console, arguments);
 }
 


### PR DESCRIPTION
Just fixes some minor things I spotted in https://github.com/kpdecker/jsdiff/pull/593; see individual commit messages for explanations. This is NOT an attempt to fully rethink the eslint config and go for an optimal ruleset for 2025, just an attempt to improve specific things I spotted and thought seemed wrong.