### PR TITLE
Remove no-longer-needed npm-debug.log entry from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 coverage
 node_modules
-npm-debug.log
 lib
 dist
 yarn-error.log


### PR DESCRIPTION
Reasons this is no longer needed:
- all the instructions for contributing this repo say to use yarn, which has never generated npm-debug.log
- since npm 4.2.0, released in 2017, npm *also* doesn't generate npm-debug.log

I noticed this while cross-checking .gitignore against .npmignore to make sure there weren't any weird generated files, not meant to be published, that we were Git-ignoring but forgetting to put in .npmignore. This was the only such inconsistency. We could resolve it by adding the same line to .npmignore, but since npm-debug.log will probably never get generated on anyone's machine ever again while they're working on jsdiff, it's probably better to just remove all reference to it.