### PR TITLE
Stop publishing runtime.js to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,7 @@ images
 index.html
 karma.conf.js
 rollup.config.mjs
+runtime.js
 src
 tasks
 test


### PR DESCRIPTION
This is just needed for running mocha tests; there's no reason to publish it.