### PR TITLE
Fix repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "git://github.com/kpdecker/jsdiff.git"
+    "url": "https://github.com/kpdecker/jsdiff.git"
   },
   "engines": {
     "node": ">=0.3.1"


### PR DESCRIPTION
We previously had the URL git://github.com/kpdecker/jsdiff.git, which uses the "Git protocol" (see https://git-scm.com/book/ms/v2/Git-on-the-Server-The-Protocols or https://stackoverflow.com/q/33846856/1709587). However, GitHub no longer supports the Git protocol (announced 2022: https://github.blog/security/application-security/improving-git-protocol-security-github/) so the URL is simply broken; trying to `git clone git://github.com/kpdecker/jsdiff.git` will hang for a while and then time out. Using https:// instead fixes it.