### PR TITLE
fix: export ArrayChange type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import {convertChangesToXML} from './convert/xml.js';
 import type {
   ChangeObject,
   Change,
+  ArrayChange,
   DiffArraysOptionsAbortable,
   DiffArraysOptionsNonabortable,
   DiffCharsOptionsAbortable,
@@ -102,6 +103,7 @@ export {
 export type {
   ChangeObject,
   Change,
+  ArrayChange,
   DiffArraysOptionsAbortable,
   DiffArraysOptionsNonabortable,
   DiffCharsOptionsAbortable,

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export interface ChangeObject<ValueT> {
 // explicitly reference by name in their own code, so keeping its name consistent is valuable even
 // though the names of many other types are inconsistent with the old DefinitelyTyped names.
 export type Change = ChangeObject<string>;
-export type ArrayChange = ChangeObject<any[]>;
+export type ArrayChange<T> = ChangeObject<T[]>;
 
 export interface CommonDiffOptions {
   /**


### PR DESCRIPTION
Adds `ArrayChange` to the type exports. This was originally exported as part of the `@types/diff` package ([code](https://www.npmjs.com/package/@types/diff/v/7.0.2?activeTab=code)), but isn't exported here. Including it will make the v8 type update simpler.

Alternatively, we could cut the type altogether since it hasn't been exported since the v8 release.