### PR TITLE
Fix diffWords crashing when used with an Intl.Segmenter on a text with consecutive newlines

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Future 8.0.3 release
+
+- [#631](https://github.com/kpdecker/jsdiff/pull/631) - **fix support for using an `Intl.Segmenter` with `diffWords`**. This has been almost completely broken since the feature was added in v6.0.0, since it would outright crash on any text that featured two consecutive newlines between a pair of words (a very common case).
+
 ## 8.0.2
 
 - [#616](https://github.com/kpdecker/jsdiff/pull/616) **Restored compatibility of `diffSentences` with old Safari versions.** This was broken in 8.0.0 by the introduction of a regex with a [lookbehind assertion](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion); these weren't supported in Safari prior to version 16.4.

--- a/test/diff/word.js
+++ b/test/diff/word.js
@@ -284,6 +284,18 @@ describe('WordDiff', function() {
         diffWords('foo', 'bar', {intlSegmenter: segmenter});
       }).to['throw']('The segmenter passed must have a granularity of "word"');
     });
+
+    it("doesn't blow up when using an Intl.Segmenter on a text with a double newline", () => {
+      // Regression test for https://github.com/kpdecker/jsdiff/issues/630
+      const englishSegmenter = new Intl.Segmenter('en', {granularity: 'word'});
+      expect(convertChangesToXML(diffWords(
+        'A\n\nX',
+        'B\n\nX',
+        {intlSegmenter: englishSegmenter}
+      ))).to.equal(
+        '<del>A</del><ins>B</ins>\n\nX'
+      );
+    });
   });
 
   describe('#diffWordsWithSpace', function() {


### PR DESCRIPTION
Fixes https://github.com/kpdecker/jsdiff/issues/630

Thanks @SonOfLilit for reporting this!