### PR TITLE
Let Corepack add a packageManager property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,5 +127,6 @@
     "lines": 100,
     "functions": 100,
     "statements": 100
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }


### PR DESCRIPTION
When I run any yarn commands in the jsdiff repo on my current dev machine (which has an installation of Node 24 that shipped with Corepack), Corepack automatically asks to install Yarn 1 and automatically adds a `packageManager` key to `package.json`. I vaguely recall that certain scripts in this repo do (or at least once did) specifically need Yarn 1 so this is probably appropriate. Might as well commit the automatic change.