### PR TITLE
Ignore .zed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ libesm
 libcjs
 dist
 yarn-error.log
-.vscode
 .nyc_output
+.vscode
+.zed

--- a/.npmignore
+++ b/.npmignore
@@ -2,8 +2,9 @@
 .eslint.config.mjs
 .gitignore
 .npmignore
-.vscode
 .nyc_output
+.vscode
+.zed
 test-d
 components
 coverage


### PR DESCRIPTION
I currently use Zed as my editor, which uses a `.zed/` folder for project-specific settings. This PR ignores that folder (similar to how we previously ignored `.vscode`, the VS Code equivalent) so I can have project-specific settings without committing them and without risking accidentally committing or publishing them.