### PR TITLE
Change 'bugs' field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
     "Kevin Decker <kpdecker@gmail.com> (http://incaseofstairs.com)",
     "Mark Amery <markrobertamery+jsdiff@gmail.com>"
   ],
-  "bugs": {
-    "email": "kpdecker@gmail.com",
-    "url": "http://github.com/kpdecker/jsdiff/issues"
-  },
+  "bugs": "http://github.com/kpdecker/jsdiff/issues",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prompted by https://github.com/kpdecker/jsdiff/issues/684. The preferred way to report most issues is via the GitHub issue tracker, and if someone _does_ want to do it by email, I'd like them to email both me and Kevin. But the `"bugs"` field can contain only one email address, so I'm nuking it. (Both our addresses are still visible elsewhere in package.json.)