### PR TITLE
fix: allow parsing empty context lines at the very end of unified diffs

### DIFF
--- a/src/patch/parse.ts
+++ b/src/patch/parse.ts
@@ -467,7 +467,7 @@ export function parsePatch(uniDiff: string): StructuredPatch[] {
       i < diffstr.length && (removeCount < hunk.oldLines || addCount < hunk.newLines || diffstr[i]?.startsWith('\\'));
       i++
     ) {
-      const operation = (diffstr[i].length == 0 && i != (diffstr.length - 1)) ? ' ' : diffstr[i][0];
+      const operation = diffstr[i].length == 0 ? ' ' : diffstr[i][0];
       if (operation === '+' || operation === '-' || operation === ' ' || operation === '\\') {
         hunk.lines.push(diffstr[i]);
 


### PR DESCRIPTION
When parsing unified diff files, empty context lines (which should technically consist of a single space `" "`) are often inadvertently truncated to completely empty strings (`""`) due to code editors trimming trailing whitespace or formatting tools removing extraneous spaces.

Currently, the `parsePatch` (specifically `parseHunk`) function successfully forgives and maps these empty strings back to a space token (`' '`), except when the empty string happens to be the last line in the `diffstr` array:

```js
// Before
const operation = (diffstr[i].length == 0 && i != (diffstr.length - 1)) ? ' ' : diffstr[i][0];
```

If a patch file ends with a trailing newline, `uniDiff.split(/\n/)` yields `""` as the last element of the array. If a hunk still expects one last context line at that exact end-of-file position, `i` points to this final `""` string. Because of the `i != (diffstr.length - 1)` check, it falls back to `diffstr[i][0]`, which evaluates to `undefined`.

Since `undefined` is not a valid operation (`+`, `-`, ` `, `\`), `parseHunk` throws an opaque error:
`Error: Hunk at line X contained invalid line`

### Changes Made:
Removed the boundary exception `&& i != (diffstr.length - 1)` condition. Empty strings are now globally and safely interpreted as empty context lines regardless of their index in the diff string.

```js
// After
const operation = diffstr[i].length == 0 ? ' ' : diffstr[i][0];
```

### Why this fixes real-world use cases:
This minor tweak prevents runtime exceptions when using `applyPatch()` on valid patch files generated by package managers (like `yarn patch` or `pnpm patch`) or saved via code editors, where a hunk requires an empty contextual line extending to the very end of the file.