### PR TITLE
Emit a better error message when a patch is truncated

### DIFF
--- a/src/patch/parse.ts
+++ b/src/patch/parse.ts
@@ -16,6 +16,15 @@ import type { StructuredPatch } from '../types.js';
 export function parsePatch(uniDiff: string): StructuredPatch[] {
   const diffstr = uniDiff.split(/\n/),
         list: Partial<StructuredPatch>[] = [];
+
+  // If the final line of the patch is missing the trailing newline character
+  // that should be present, we forgive that, but if the final character of
+  // the patch is a newline as expected, we don't consider there to be a
+  // further blank line afterwards. We remove that blank line here:
+  if (diffstr[diffstr.length - 1] == '') {
+    diffstr.pop();
+  }
+
   let i = 0;
 
   // These helper functions identify line types that can appear between files
@@ -494,10 +503,14 @@ export function parsePatch(uniDiff: string): StructuredPatch[] {
 
     // Perform sanity checking
     if (addCount !== hunk.newLines) {
-      throw new Error('Added line count did not match for hunk at line ' + (chunkHeaderIndex + 1));
+      throw new Error(
+        `New line count did not match for hunk at line ${chunkHeaderIndex + 1}; expected ${hunk.newLines} but got ${addCount}`
+      );
     }
     if (removeCount !== hunk.oldLines) {
-      throw new Error('Removed line count did not match for hunk at line ' + (chunkHeaderIndex + 1));
+      throw new Error(
+        `Old line count did not match for hunk at line ${chunkHeaderIndex + 1}; expected ${hunk.oldLines} but got ${removeCount}`
+      );
     }
 
     // Check for extra hunk-body-like lines after the declared line counts

--- a/test/patch/parse.js
+++ b/test/patch/parse.js
@@ -666,10 +666,10 @@ more garbage
 
       expect(function() {
         parsePatch('@@ -1 +1,4 @@');
-      }).to['throw']('Added line count did not match for hunk at line 1');
+      }).to['throw']('New line count did not match for hunk at line 1; expected 4 but got 0');
       expect(function() {
         parsePatch('@@ -1,4 +1 @@');
-      }).to['throw']('Removed line count did not match for hunk at line 1');
+      }).to['throw']('Old line count did not match for hunk at line 1; expected 4 but got 0');
     });
 
 
@@ -937,6 +937,22 @@ line3
 
       // eslint-disable-next-line dot-notation
       expect(() => {parsePatch(patchStr);}).to.throw('Hunk at line 5 contained invalid line line3');
+    });
+
+    it('should emit a useful error message if the final hunk of the patch file ends prematurely', () => {
+      const patchStr = `Index: test
+===================================================================
+--- from\theader1
++++ to\theader2
+@@ -1,4 +1,5 @@
+ line2
+ line3
++line4
+ line5`;
+      // eslint-disable-next-line dot-notation
+      expect(() => { parsePatch(patchStr); }).to.throw(
+        'New line count did not match for hunk at line 5; expected 5 but got 4'
+      );
     });
 
     it('should parse a single-file `diff --git` patch', function() {

--- a/test/patch/parse.js
+++ b/test/patch/parse.js
@@ -949,8 +949,15 @@ line3
  line3
 +line4
  line5`;
+      const patchStr2 = patchStr + '\n';
+
       // eslint-disable-next-line dot-notation
       expect(() => { parsePatch(patchStr); }).to.throw(
+        'New line count did not match for hunk at line 5; expected 5 but got 4'
+      );
+
+      // eslint-disable-next-line dot-notation
+      expect(() => { parsePatch(patchStr2); }).to.throw(
         'New line count did not match for hunk at line 5; expected 5 but got 4'
       );
     });


### PR DESCRIPTION
I propose this as a more conservative way to resolve https://github.com/kpdecker/jsdiff/pull/690. At least this will make clear to the end user what the problem is. Given that the only way we know of so far that one can stumble into generating a truncated patch like this is manually editing it in an editor with trim-on-save behaviour, it should usually be no big deal for an end user to fix the problem after seeing the error message.

Alternatives considered but that I don't really like:
- Making the default behaviour really liberal, like [that of Unix patch](https://github.com/kpdecker/jsdiff/pull/690#issuecomment-4554398012). Trouble is this behaviour is arbitrary, surprising, and could easily hide more meaningful corruption of patches.
- Adding a strict mode controlled by a boolean option. Doesn't seem worth the extra API complexity to solve a problem that will only affect people who are manually editing patches.

The only further angle for improving the state of the world I have considered was to see if anything can be reasonably changed in *editors*. In an editor that has trim-on-save enabled by default and also supports syntax-specific settings (and has some such settings configured by default), trim-on-save behaviour should probably be disabled by default for patch files.

Except in my current editor, Zed, that's already the case; default settings contain:

```
    "Diff": {
      "show_edit_predictions": false,
      "remove_trailing_whitespace_on_save": false,
      "ensure_final_newline_on_save": false,
    },
```

and I think VSCode has trim-on-save off by default globally.

So I reckon the best I can do is just this. Commentary welcome.