### PR TITLE
Attempt to fix canonicalize on deep objects

### DIFF
--- a/src/diff/json.ts
+++ b/src/diff/json.ts
@@ -1,6 +1,7 @@
 import Diff from './base.js';
 import type { ChangeObject, CallbackOptionAbortable, CallbackOptionNonabortable, DiffCallbackNonabortable, DiffJsonOptionsAbortable, DiffJsonOptionsNonabortable} from '../types.js';
 import { tokenize } from './line.js';
+import { canonicalize } from './json/canonicalize.js';
 
 class JsonDiff extends Diff<string, string, string | object> {
   get useLongestToken() {
@@ -14,7 +15,7 @@ class JsonDiff extends Diff<string, string, string | object> {
   castInput(value: string | object, options: DiffJsonOptionsNonabortable | DiffJsonOptionsAbortable) {
     const {undefinedReplacement, stringifyReplacer = (k, v) => typeof v === 'undefined' ? undefinedReplacement : v} = options;
 
-    return typeof value === 'string' ? value : JSON.stringify(canonicalize(value, null, null, stringifyReplacer), null, '  ');
+    return typeof value === 'string' ? value : JSON.stringify(canonicalize(value, stringifyReplacer), null, '  ');
   }
 
   equals(left: string, right: string, options: DiffJsonOptionsNonabortable | DiffJsonOptionsAbortable) {
@@ -57,71 +58,4 @@ export function diffJson(
 ): ChangeObject<string>[]
 export function diffJson(oldStr: string | object, newStr: string | object, options?: any): undefined | ChangeObject<string>[] {
   return jsonDiff.diff(oldStr, newStr, options);
-}
-
-
-// This function handles the presence of circular references by bailing out when encountering an
-// object that is already on the "stack" of items being processed. Accepts an optional replacer
-export function canonicalize(
-  obj: any,
-  stack: Array<any> | null, replacementStack: Array<any> | null,
-  replacer: (k: string, v: any) => any,
-  key?: string
-) {
-  stack = stack || [];
-  replacementStack = replacementStack || [];
-
-  if (replacer) {
-    obj = replacer(key === undefined ? '' : key, obj);
-  }
-
-  let i;
-
-  for (i = 0; i < stack.length; i += 1) {
-    if (stack[i] === obj) {
-      return replacementStack[i];
-    }
-  }
-
-  let canonicalizedObj: any;
-
-  if ('[object Array]' === Object.prototype.toString.call(obj)) {
-    stack.push(obj);
-    canonicalizedObj = new Array(obj.length);
-    replacementStack.push(canonicalizedObj);
-    for (i = 0; i < obj.length; i += 1) {
-      canonicalizedObj[i] = canonicalize(obj[i], stack, replacementStack, replacer, String(i));
-    }
-    stack.pop();
-    replacementStack.pop();
-    return canonicalizedObj;
-  }
-
-  if (obj && obj.toJSON) {
-    obj = obj.toJSON();
-  }
-
-  if (typeof obj === 'object' && obj !== null) {
-    stack.push(obj);
-    canonicalizedObj = {};
-    replacementStack.push(canonicalizedObj);
-    const sortedKeys = [];
-    let key;
-    for (key in obj) {
-      /* istanbul ignore else */
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        sortedKeys.push(key);
-      }
-    }
-    sortedKeys.sort();
-    for (i = 0; i < sortedKeys.length; i += 1) {
-      key = sortedKeys[i];
-      canonicalizedObj[key] = canonicalize(obj[key], stack, replacementStack, replacer, key);
-    }
-    stack.pop();
-    replacementStack.pop();
-  } else {
-    canonicalizedObj = obj;
-  }
-  return canonicalizedObj;
 }

--- a/src/diff/json/canonicalize.ts
+++ b/src/diff/json/canonicalize.ts
@@ -58,6 +58,10 @@ export function canonicalize(obj: any, replacer: (k: string, v: any) => any) {
           ancestorsLl
         });
       }
+    } else if (replacedValue && replacedValue.toJSON) {
+      // Convert dates to strings - don't replace them with empty objects
+      // as the subsequent clause for objects would otherwise do
+      canonicalizedValue = replacedValue.toJSON();
     } else if (typeof replacedValue === 'object' && obj !== null) {
       canonicalizedValue = {};
       for (const key of Object.keys(replacedValue).sort()) {

--- a/src/diff/json/canonicalize.ts
+++ b/src/diff/json/canonicalize.ts
@@ -62,7 +62,7 @@ export function canonicalize(obj: any, replacer: (k: string, v: any) => any) {
       // Convert dates to strings - don't replace them with empty objects
       // as the subsequent clause for objects would otherwise do
       canonicalizedValue = replacedValue.toJSON();
-    } else if (typeof replacedValue === 'object' && obj !== null) {
+    } else if (typeof replacedValue === 'object' && replacedValue !== null) {
       canonicalizedValue = {};
       for (const key of Object.keys(replacedValue).sort()) {
         if (Object.prototype.hasOwnProperty.call(replacedValue, key)) {

--- a/src/diff/json/canonicalize.ts
+++ b/src/diff/json/canonicalize.ts
@@ -1,5 +1,6 @@
 interface AncestorsLlNode {
-  val: { [k: string]: any } | any[];
+  rawValue: { [k: string]: any } | any[];
+  canonicalizedValue: any,
   next: AncestorsLlNode | null;
 }
 
@@ -10,17 +11,15 @@ interface CanonicalizeTask {
   ancestorsLl: AncestorsLlNode;
 }
 
-function llContains(haystack: AncestorsLlNode | null, needle: any) {
+function duplicateAncestor(haystack: AncestorsLlNode | null, needle: any) {
   while (haystack) {
-    if (haystack.val === needle) {
-      return true;
+    if (haystack.rawValue === needle) {
+      return haystack;
     }
     haystack = haystack.next;
   }
   return false;
 }
-
-const REFERENCE_CYCLE_DETECTED = Symbol();
 
 export function canonicalize(obj: any, replacer: (k: string, v: any) => any) {
   const wrapper: any = {};
@@ -29,53 +28,57 @@ export function canonicalize(obj: any, replacer: (k: string, v: any) => any) {
       parent: wrapper,
       key: 'root',
       rawValue: obj,
-      ancestorsLl: { val: wrapper, next: null }
+      ancestorsLl: { rawValue: wrapper, next: null, canonicalizedValue: wrapper }
     }
   ];
 
   function doTask(task: CanonicalizeTask): any {
-    if (llContains(task.ancestorsLl, task.rawValue)) {
-      return REFERENCE_CYCLE_DETECTED;
-    }
-    const ancestorsLl = { val: task.rawValue, next: task.ancestorsLl };
-    // Step 1: run the replacer
-    const replacedValue = replacer(
-      task.rawValue === obj ? '' : String(task.key),
-      task.rawValue
-    );
-
-    // Step 2: replace objects and arrays with new, empty ones, and queue up
-    // tasks to populate those empty objects with canonicalized versions of
-    // their original contents. Also sort object keys alphabetically.
     let canonicalizedValue: any;
-    if ('[object Array]' === Object.prototype.toString.call(replacedValue)) {
-      canonicalizedValue = new Array(replacedValue.length);
-      for (let i = 0; i < replacedValue.length; i += 1) {
-        tasks.push({
-          parent: canonicalizedValue,
-          key: i,
-          rawValue: replacedValue[i],
-          ancestorsLl
-        });
-      }
-    } else if (replacedValue && replacedValue.toJSON) {
-      // Convert dates to strings - don't replace them with empty objects
-      // as the subsequent clause for objects would otherwise do
-      canonicalizedValue = replacedValue.toJSON();
-    } else if (typeof replacedValue === 'object' && replacedValue !== null) {
-      canonicalizedValue = {};
-      for (const key of Object.keys(replacedValue).sort()) {
-        if (Object.prototype.hasOwnProperty.call(replacedValue, key)) {
+
+    // If we've encountered a reference cycle, bail out of it rather than
+    // following it in circles forever, and skip steps 1 and 2 below.
+    const dupe = duplicateAncestor(task.ancestorsLl, task.rawValue);
+    if (dupe) {
+      canonicalizedValue = dupe.canonicalizedValue;
+    } else {
+      // Step 1: run the replacer
+      const replacedValue = replacer(
+        task.rawValue === obj ? '' : String(task.key),
+        task.rawValue
+      );
+
+      // Step 2: replace objects and arrays with new, empty ones, and queue up
+      // tasks to populate those empty objects with canonicalized versions of
+      // their original contents. Also sort object keys alphabetically.
+      if ('[object Array]' === Object.prototype.toString.call(replacedValue)) {
+        canonicalizedValue = new Array(replacedValue.length);
+        for (let i = 0; i < replacedValue.length; i += 1) {
           tasks.push({
             parent: canonicalizedValue,
-            key,
-            rawValue: replacedValue[key],
-            ancestorsLl
+            key: i,
+            rawValue: replacedValue[i],
+            ancestorsLl: { rawValue: task.rawValue, next: task.ancestorsLl, canonicalizedValue }
           });
         }
+      } else if (replacedValue && replacedValue.toJSON) {
+        // Convert dates to strings - don't replace them with empty objects
+        // as the subsequent clause for objects would otherwise do
+        canonicalizedValue = replacedValue.toJSON();
+      } else if (typeof replacedValue === 'object' && replacedValue !== null) {
+        canonicalizedValue = {};
+        for (const key of Object.keys(replacedValue).sort()) {
+          if (Object.prototype.hasOwnProperty.call(replacedValue, key)) {
+            tasks.push({
+              parent: canonicalizedValue,
+              key,
+              rawValue: replacedValue[key],
+              ancestorsLl: { rawValue: task.rawValue, next: task.ancestorsLl, canonicalizedValue }
+            });
+          }
+        }
+      } else {
+        canonicalizedValue = replacedValue;
       }
-    } else {
-      canonicalizedValue = replacedValue;
     }
 
     // Step 3: insert the new value into the parent object
@@ -83,9 +86,7 @@ export function canonicalize(obj: any, replacer: (k: string, v: any) => any) {
   }
 
   for (let taskIndex = 0; taskIndex <= tasks.length - 1; taskIndex++) {
-    if (doTask(tasks[taskIndex]) === REFERENCE_CYCLE_DETECTED) {
-      return obj;
-    }
+    doTask(tasks[taskIndex]);
   }
   return wrapper.root;
 }

--- a/src/diff/json/canonicalize.ts
+++ b/src/diff/json/canonicalize.ts
@@ -1,0 +1,87 @@
+interface AncestorsLlNode {
+  val: { [k: string]: any } | any[];
+  next: AncestorsLlNode | null;
+}
+
+interface CanonicalizeTask {
+  parent: { [k: string]: any } | any[];
+  key: string | number;
+  rawValue: any;
+  ancestorsLl: AncestorsLlNode;
+}
+
+function llContains(haystack: AncestorsLlNode | null, needle: any) {
+  while (haystack) {
+    if (haystack.val === needle) {
+      return true;
+    }
+    haystack = haystack.next;
+  }
+  return false;
+}
+
+const REFERENCE_CYCLE_DETECTED = Symbol();
+
+export function canonicalize(obj: any, replacer: (k: string, v: any) => any) {
+  const wrapper: any = {};
+  const tasks: CanonicalizeTask[] = [
+    {
+      parent: wrapper,
+      key: 'root',
+      rawValue: obj,
+      ancestorsLl: { val: wrapper, next: null }
+    }
+  ];
+
+  function doTask(task: CanonicalizeTask): any {
+    if (llContains(task.ancestorsLl, task.rawValue)) {
+      return REFERENCE_CYCLE_DETECTED;
+    }
+    const ancestorsLl = { val: task.rawValue, next: task.ancestorsLl };
+    // Step 1: run the replacer
+    const replacedValue = replacer(
+      task.rawValue === obj ? '' : String(task.key),
+      task.rawValue
+    );
+
+    // Step 2: replace objects and arrays with new, empty ones, and queue up
+    // tasks to populate those empty objects with canonicalized versions of
+    // their original contents. Also sort object keys alphabetically.
+    let canonicalizedValue: any;
+    if ('[object Array]' === Object.prototype.toString.call(replacedValue)) {
+      canonicalizedValue = new Array(replacedValue.length);
+      for (let i = 0; i < replacedValue.length; i += 1) {
+        tasks.push({
+          parent: canonicalizedValue,
+          key: i,
+          rawValue: replacedValue[i],
+          ancestorsLl
+        });
+      }
+    } else if (typeof replacedValue === 'object' && obj !== null) {
+      canonicalizedValue = {};
+      for (const key of Object.keys(replacedValue).sort()) {
+        if (Object.prototype.hasOwnProperty.call(replacedValue, key)) {
+          tasks.push({
+            parent: canonicalizedValue,
+            key,
+            rawValue: replacedValue[key],
+            ancestorsLl
+          });
+        }
+      }
+    } else {
+      canonicalizedValue = replacedValue;
+    }
+
+    // Step 3: insert the new value into the parent object
+    (task.parent as any)[task.key] = canonicalizedValue;
+  }
+
+  for (let taskIndex = 0; taskIndex <= tasks.length - 1; taskIndex++) {
+    if (doTask(tasks[taskIndex]) === REFERENCE_CYCLE_DETECTED) {
+      return obj;
+    }
+  }
+  return wrapper.root;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import {diffLines, diffTrimmedLines, lineDiff} from './diff/line.js';
 import {diffSentences, sentenceDiff} from './diff/sentence.js';
 
 import {diffCss, cssDiff} from './diff/css.js';
-import {diffJson, canonicalize, jsonDiff} from './diff/json.js';
+import { diffJson, jsonDiff } from './diff/json.js';
 
 import {diffArrays, arrayDiff} from './diff/array.js';
 
@@ -103,8 +103,7 @@ export {
   parsePatch,
   reversePatch,
   convertChangesToDMP,
-  convertChangesToXML,
-  canonicalize
+  convertChangesToXML
 };
 
 export type {

--- a/test/diff/json.js
+++ b/test/diff/json.js
@@ -117,7 +117,7 @@ describe('diff/json', function() {
   });
 
   describe('#canonicalize', function() {
-    function noop(x) { return x; }
+    function noop(k, v) { return v; }
 
     it('should put the keys in canonical order', function() {
       expect(Object.keys(canonicalize({b: 456, a: 123}, noop))).to.eql(['a', 'b']);

--- a/test/diff/json.js
+++ b/test/diff/json.js
@@ -136,9 +136,10 @@ describe('diff/json', function() {
     it('should handle circular references correctly', function() {
       const obj = {b: 456};
       obj.a = obj;
-      const canonicalObj = canonicalize(obj, noop);
+      const canonicalObj = canonicalize(obj, (k, v) => k == 'b' ? v + 1 : v);
       expect(Object.keys(canonicalObj)).to.eql(['a', 'b']);
-      expect(Object.keys(canonicalObj.a)).to.eql(['a', 'b']);
+      expect(canonicalObj.a).to.eql(canonicalObj);
+      expect(canonicalObj.a.a.a.a.a.b).to.eql(457);
     });
 
     it('should accept a custom JSON.stringify() replacer function', function() {

--- a/test/diff/json.js
+++ b/test/diff/json.js
@@ -113,6 +113,21 @@ describe('diff/json', function() {
         );
       }).to['throw'](/circular|cyclic/i);
     });
+
+    it('can handle deeply-nested objects without exploding (e.g. due to recursion depth)', () => {
+      // Regression test for https://github.com/kpdecker/jsdiff/issues/689
+      function makeNested(depth) {
+        let obj = {};
+        let cur = obj;
+        for (let i = 0; i < depth; i++) {
+          cur.child = {};
+          cur = cur.child;
+        }
+        return obj;
+      }
+      const deepObj = makeNested(1000000);
+      expect(() => diffJson(deepObj, {})).not.to['throw']();
+    });
   });
 
   describe('#canonicalize', function() {

--- a/test/diff/json.js
+++ b/test/diff/json.js
@@ -1,4 +1,5 @@
-import {diffJson, canonicalize} from '../../libesm/diff/json.js';
+import { diffJson } from '../../libesm/diff/json.js';
+import { canonicalize } from '../../libesm/diff/json/canonicalize.js';
 import {convertChangesToXML} from '../../libesm/convert/xml.js';
 
 import {expect} from 'chai';
@@ -116,24 +117,26 @@ describe('diff/json', function() {
   });
 
   describe('#canonicalize', function() {
+    function noop(x) { return x; }
+
     it('should put the keys in canonical order', function() {
-      expect(Object.keys(canonicalize({b: 456, a: 123}))).to.eql(['a', 'b']);
+      expect(Object.keys(canonicalize({b: 456, a: 123}, noop))).to.eql(['a', 'b']);
     });
 
     it('should dive into nested objects', function() {
-      const canonicalObj = canonicalize({b: 456, a: {d: 123, c: 456}});
+      const canonicalObj = canonicalize({b: 456, a: {d: 123, c: 456}}, noop);
       expect(Object.keys(canonicalObj.a)).to.eql(['c', 'd']);
     });
 
     it('should dive into nested arrays', function() {
-      const canonicalObj = canonicalize({b: 456, a: [789, {d: 123, c: 456}]});
+      const canonicalObj = canonicalize({b: 456, a: [789, {d: 123, c: 456}]}, noop);
       expect(Object.keys(canonicalObj.a[1])).to.eql(['c', 'd']);
     });
 
     it('should handle circular references correctly', function() {
       const obj = {b: 456};
       obj.a = obj;
-      const canonicalObj = canonicalize(obj);
+      const canonicalObj = canonicalize(obj, noop);
       expect(Object.keys(canonicalObj)).to.eql(['a', 'b']);
       expect(Object.keys(canonicalObj.a)).to.eql(['a', 'b']);
     });

--- a/test/diff/json.js
+++ b/test/diff/json.js
@@ -126,7 +126,7 @@ describe('diff/json', function() {
         }
         return obj;
       }
-      const deepObj = makeNested(1000000);
+      const deepObj = makeNested(15000);
       expect(() => diffJson(deepObj, {})).not.to['throw']();
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,5 @@ describe('root exports', function() {
     expect(Diff.parsePatch).to.exist;
     expect(Diff.convertChangesToDMP).to.exist;
     expect(Diff.convertChangesToXML).to.exist;
-    expect(Diff.canonicalize).to.exist;
   });
 });


### PR DESCRIPTION
This was an ill-conceived attempt to fix https://github.com/kpdecker/jsdiff/issues/689. I am opening this PR for the record, and because in future it may become reasonable to merge (if the behaviour of JSON.stringify in prevailing JavaScript environments changes), but for now it is pointless. See explanation I'm about to post in #689.