### PR TITLE
Fix diffJson silently dropping an own __proto__ key (#696)

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 9.1.0 (prerelease)
+
+- [#697](https://github.com/kpdecker/jsdiff/pull/697) *`diffJson` now correctly handles JSON objects containing a key named `__proto__`*. (Previously, the returned diff would be as if the `__proto__` key did not exist on either of the objects being diffed.)
+
 ## 9.0.0
 
 (All changes part of PR [#672](https://github.com/kpdecker/jsdiff/pull/672).)

--- a/src/diff/json.ts
+++ b/src/diff/json.ts
@@ -103,7 +103,10 @@ export function canonicalize(
 
   if (typeof obj === 'object' && obj !== null) {
     stack.push(obj);
-    canonicalizedObj = {};
+    // Use a null-prototype object so that an own "__proto__" key is stored as
+    // a normal property instead of triggering the Object.prototype setter,
+    // which would silently drop the key from the canonicalized output.
+    canonicalizedObj = Object.create(null);
     replacementStack.push(canonicalizedObj);
     const sortedKeys = [];
     let key;

--- a/test/diff/json.js
+++ b/test/diff/json.js
@@ -113,6 +113,20 @@ describe('diff/json', function() {
         );
       }).to['throw'](/circular|cyclic/i);
     });
+
+    it('does not silently drop an own __proto__ property', function() {
+      // Objects parsed from JSON can carry an own enumerable "__proto__"
+      // property. Diffing must reflect a change to it instead of reporting
+      // the two objects as identical.
+      const oldObj = JSON.parse('{"__proto__": "old"}');
+      const newObj = JSON.parse('{"__proto__": "new"}');
+      expect(diffJson(oldObj, newObj)).to.eql([
+        { count: 1, value: '{\n', removed: false, added: false },
+        { count: 1, value: '  "__proto__": "old"\n', added: false, removed: true },
+        { count: 1, value: '  "__proto__": "new"\n', added: true, removed: false },
+        { count: 1, value: '}', removed: false, added: false }
+      ]);
+    });
   });
 
   describe('#canonicalize', function() {


### PR DESCRIPTION
Fixes #696.

### Problem

`diffJson` reports two objects that differ only in an own `__proto__` property as identical:

```js
diffJson(JSON.parse('{"__proto__":"old"}'), JSON.parse('{"__proto__":"new"}'))
// => [ { count: 1, value: "{}", added: false, removed: false } ]   // no diff!
```

### Root cause

`canonicalize` (src/diff/json.ts) builds its output object with `{}`. That object inherits `Object.prototype`, so `canonicalizedObj["__proto__"] = value` invokes the `__proto__` **setter** instead of creating an own data property. The key is silently discarded, both sides canonicalize to `{}`, and `diffJson` sees no difference. Objects parsed from JSON (e.g. `JSON.parse`) can legitimately carry an own enumerable `__proto__` property, so this is silent data loss.

### Fix

Build the canonicalized object with `Object.create(null)`, so a `"__proto__"` key is stored as an ordinary property. This is the approach suggested (unverified) by the reporter in #696; this PR verifies it and adds test coverage. `canonicalize` output is only ever `JSON.stringify`-d or key-walked, both of which work on null-prototype objects, and the existing `#canonicalize` tests (which read `Object.keys(...)`) still pass.

### Test

Added a regression test in `test/diff/json.js` diffing two JSON-parsed objects with an own `__proto__` property. Red-green verified: before the fix the assertion fails (single unchanged `"{}"` hunk); after, it produces the expected removed/added `__proto__` lines. The full mocha suite passes (one unrelated pre-existing timeout on the enormous-hunk perf test in `test/patch/create.js`, which passes with a higher `--timeout`); `eslint` is clean.

---

Disclosure: prepared with AI assistance (Claude); I reviewed it and verified the red-green test and the full test suite.