### PR TITLE
fix: don't treat a literal CR at EOF as a Windows line ending

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -4,6 +4,7 @@
 
 - [#697](https://github.com/kpdecker/jsdiff/pull/697) *`diffJson` now correctly handles JSON objects containing a key named `__proto__`*. (Previously, the returned diff would be as if the `__proto__` key did not exist on either of the objects being diffed.)
 - [#700](https://github.com/kpdecker/jsdiff/pull/700) *`diffJson` now correctly handles JSON objects containing a non-callable property named `toJSON`* - i.e. it gives such a property no special behaviour whatsoever, just as `JSON.stringify` doesn't. Previously, such properties caused an error to be thrown. (*Callable* `toJSON` properties continue to get the same special behaviour that `JSON.stringify` gives them.)
+- [#701](https://github.com/kpdecker/jsdiff/pull/701) *`applyPatch` with `autoConvertLineEndings` on will no longer consider a stray `\r` character occurring at the end of a file without a terminating `\n` character to be a Windows line ending*, and so will no longer strip it when converting from Windows to Unix line endings.
 
 ## 9.0.0
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -4,7 +4,7 @@
 
 - [#697](https://github.com/kpdecker/jsdiff/pull/697) *`diffJson` now correctly handles JSON objects containing a key named `__proto__`*. (Previously, the returned diff would be as if the `__proto__` key did not exist on either of the objects being diffed.)
 - [#700](https://github.com/kpdecker/jsdiff/pull/700) *`diffJson` now correctly handles JSON objects containing a non-callable property named `toJSON`* - i.e. it gives such a property no special behaviour whatsoever, just as `JSON.stringify` doesn't. Previously, such properties caused an error to be thrown. (*Callable* `toJSON` properties continue to get the same special behaviour that `JSON.stringify` gives them.)
-- [#701](https://github.com/kpdecker/jsdiff/pull/701) *`applyPatch` with `autoConvertLineEndings` on will no longer consider a stray `\r` character occurring at the end of a file without a terminating `\n` character to be a Windows line ending*, and so will no longer strip it when converting from Windows to Unix line endings or fail to apply a Unix-style patch to a Windows file when the patch introduces such a stray `\r`.
+- [#701](https://github.com/kpdecker/jsdiff/pull/701) *`applyPatch` with `autoConvertLineEndings` on will no longer consider a stray `\r` character occurring at the end of a file without a terminating `\n` character to be a Windows line ending*, and so will no longer strip it when converting from Windows to Unix line endings nor fail to apply a Unix-style patch to a Windows file when the patch introduces such a stray `\r`.
 
 ## 9.0.0
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -4,6 +4,7 @@
 
 - [#697](https://github.com/kpdecker/jsdiff/pull/697) *`diffJson` now correctly handles JSON objects containing a key named `__proto__`*. (Previously, the returned diff would be as if the `__proto__` key did not exist on either of the objects being diffed.)
 - [#700](https://github.com/kpdecker/jsdiff/pull/700) *`diffJson` now correctly handles JSON objects containing a non-callable property named `toJSON`* - i.e. it gives such a property no special behaviour whatsoever, just as `JSON.stringify` doesn't. Previously, such properties caused an error to be thrown. (*Callable* `toJSON` properties continue to get the same special behaviour that `JSON.stringify` gives them.)
+- [#701](https://github.com/kpdecker/jsdiff/pull/701) *`applyPatch` with `autoConvertLineEndings` on will no longer consider a stray `\r` character occurring at the end of a file without a terminating `\n` character to be a Windows line ending*, and so will no longer strip it when converting from Windows to Unix line endings or fail to apply a Unix-style patch to a Windows file when the patch introduces such a stray `\r`.
 
 ## 9.0.0
 

--- a/src/patch/line-endings.ts
+++ b/src/patch/line-endings.ts
@@ -55,7 +55,7 @@ export function isUnix(patch: StructuredPatch | StructuredPatch[]): boolean {
   return !patch.some(
     index => index.hunks.some(
       hunk => hunk.lines.some(
-        line => !line.startsWith('\\') && line.endsWith('\r')
+        (line, i) => !line.startsWith('\\') && line.endsWith('\r') && !hunk.lines[i + 1]?.startsWith('\\')
       )
     )
   );

--- a/src/patch/line-endings.ts
+++ b/src/patch/line-endings.ts
@@ -41,7 +41,16 @@ export function winToUnix(patch: StructuredPatch | StructuredPatch[]): Structure
     ...patch,
     hunks: patch.hunks.map(hunk => ({
       ...hunk,
-      lines: hunk.lines.map(line => line.endsWith('\r') ? line.substring(0, line.length - 1) : line)
+      lines: hunk.lines.map(
+        (line, i) =>
+          // A trailing '\r' on a line immediately followed by a "\ No newline at end of file"
+          // marker is not a Windows line ending (a Windows EOL is '\r\n'); it's a literal carriage
+          // return in the final line's content. Stripping it would corrupt the content, so we leave
+          // such lines alone. (This mirrors the equivalent guard in unixToWin.)
+          (line.endsWith('\r') && !hunk.lines[i + 1]?.startsWith('\\'))
+            ? line.substring(0, line.length - 1)
+            : line
+      )
     }))
   };
 }
@@ -66,7 +75,16 @@ export function isUnix(patch: StructuredPatch | StructuredPatch[]): boolean {
  */
 export function isWin(patch: StructuredPatch | StructuredPatch[]): boolean {
   if (!Array.isArray(patch)) { patch = [patch]; }
-  return patch.some(index => index.hunks.some(hunk => hunk.lines.some(line => line.endsWith('\r'))))
+  return patch.some(
+    index => index.hunks.some(
+      hunk => hunk.lines.some(
+        // A trailing '\r' before a "\ No newline at end of file" marker is a literal carriage
+        // return in the final line's content, not a Windows line ending, so it isn't evidence that
+        // the patch uses Windows line endings.
+        (line, i) => line.endsWith('\r') && !hunk.lines[i + 1]?.startsWith('\\')
+      )
+    )
+  )
     && patch.every(
       index => index.hunks.every(
         hunk => hunk.lines.every(

--- a/test/patch/apply.js
+++ b/test/patch/apply.js
@@ -1422,6 +1422,19 @@ describe('patch/apply', function() {
         .to.equal('');
     });
 
+    it('should correctly apply a Unix patch whose final added line ends with a literal \\r (no newline at EOF) to a Windows file', () => {
+      // The patch is Unix-style (no \\r\\n line endings), but the added line's content ends with a
+      // literal '\\r' because the new file has no trailing newline. autoConvertLineEndings must
+      // recognise the patch as Unix (not Windows), convert it to match the CRLF source, and apply
+      // it correctly — without dropping the literal '\\r'. Previously, isUnix() returned false for
+      // such a patch, so no conversion was attempted and applyPatch returned false.
+      const oldFileUnix = 'line1\nline2\n';
+      const newFileUnix = 'line1\nline3\r'; // final line has literal CR and no trailing newline
+      const patch = structuredPatch('test', 'test', oldFileUnix, newFileUnix, undefined, undefined, {context: 0});
+      const oldFileWin = 'line1\r\nline2\r\n';
+      expect(applyPatch(oldFileWin, patch)).to.equal('line1\r\nline3\r');
+    });
+
     it('should automatically convert a patch with Unix file endings to Windows when patching a Windows file', () => {
       const oldFile = 'foo\r\nbar\r\nbaz\r\nqux\r\n';
       const diffFile =

--- a/test/patch/apply.js
+++ b/test/patch/apply.js
@@ -1423,6 +1423,7 @@ describe('patch/apply', function() {
     });
 
     it('should correctly apply a Unix patch whose final added line ends with a literal \\r (no newline at EOF) to a Windows file', () => {
+      // Regression test for bug fixed in https://github.com/kpdecker/jsdiff/pull/701
       // The patch is Unix-style (no \\r\\n line endings), but the added line's content ends with a
       // literal '\\r' because the new file has no trailing newline. autoConvertLineEndings must
       // recognise the patch as Unix (not Windows), convert it to match the CRLF source, and apply
@@ -1489,6 +1490,7 @@ describe('patch/apply', function() {
     });
 
     it('should not strip a literal carriage return from a no-newline-at-EOF line when patching a Unix file', () => {
+      // Regression test for bug fixed in https://github.com/kpdecker/jsdiff/pull/701
       // The final line's content ends with a literal '\r' and has no trailing newline. This '\r' is
       // not a Windows line ending (those are '\r\n'), so autoConvertLineEndings must not strip it -
       // doing so previously corrupted the output, losing the carriage return.

--- a/test/patch/apply.js
+++ b/test/patch/apply.js
@@ -1475,6 +1475,16 @@ describe('patch/apply', function() {
       expect(applyPatch(oldFile2, diffFile)).to.equal('foo\nnew\r\ntwo\r\nthree\r\nqux\n');
     });
 
+    it('should not strip a literal carriage return from a no-newline-at-EOF line when patching a Unix file', () => {
+      // The final line's content ends with a literal '\r' and has no trailing newline. This '\r' is
+      // not a Windows line ending (those are '\r\n'), so autoConvertLineEndings must not strip it -
+      // doing so previously corrupted the output, losing the carriage return.
+      const oldFile = 'line1\nline2\n';
+      const newFile = 'line1\nline2\nline3\r';
+      const patch = structuredPatch('test', 'test', oldFile, newFile, undefined, undefined, {context: 0});
+      expect(applyPatch(oldFile, patch)).to.equal(newFile);
+    });
+
     it('should leave patch file endings alone if autoConvertLineEndings=false', () => {
       const oldFile = 'foo\r\nbar\r\nbaz\r\nqux\r\n';
       const diffFile =

--- a/test/patch/line-endings.js
+++ b/test/patch/line-endings.js
@@ -148,4 +148,19 @@ describe('isUnix', () => {
     );
     expect(isUnix(patch)).to.equal(true);
   });
+
+  it('should still return true if only the last line in a file is missing a LF and there is a no newline at EOF indicator', () => {
+    const patch = parsePatch(
+      'Index: test\n'
+      + '===================================================================\n'
+      + '--- test\theader1\n'
+      + '+++ test\theader2\n'
+      + '@@ -1,2 +1,3 @@\n'
+      + ' line2\n'
+      + ' line3\n'
+      + '+line4\r\n'
+      + '\\ No newline at end of file\n'
+    );
+    expect(isUnix(patch)).to.equal(true);
+  });
 });

--- a/test/patch/line-endings.js
+++ b/test/patch/line-endings.js
@@ -73,6 +73,35 @@ describe('unixToWin and winToUnix', function() {
       + '\\ No newline at end of file\n'
     );
   });
+
+  it('winToUnix should not strip a literal \\r from the last line if there was no newline at EOF', () => {
+    // The final line's content ends with a literal '\r' with no trailing newline. That '\r' is not
+    // a Windows line ending (those are '\r\n'), so it must be left alone rather than stripped.
+    const patch = parsePatch(
+      'Index: test\n'
+      + '===================================================================\n'
+      + '--- test\theader1\n'
+      + '+++ test\theader2\n'
+      + '@@ -1,2 +1,2 @@\n'
+      + ' line2\r\n'
+      + '-line3\r\n'
+      + '+line3changed\r\n'
+      + '\\ No newline at end of file\n'
+    );
+
+    const unixPatch = winToUnix(patch);
+    expect(formatPatch(unixPatch)).to.equal(
+      'Index: test\n'
+      + '===================================================================\n'
+      + '--- test\theader1\n'
+      + '+++ test\theader2\n'
+      + '@@ -1,2 +1,2 @@\n'
+      + ' line2\n'
+      + '-line3\n'
+      + '+line3changed\r\n'
+      + '\\ No newline at end of file\n'
+    );
+  });
 });
 
 describe('isWin', () => {
@@ -117,6 +146,19 @@ describe('isWin', () => {
       + '\\ No newline at end of file\n'
     );
     expect(isWin(patch)).to.equal(true);
+  });
+
+  it('should return false if the only line ending in a CR is a no-newline-at-EOF line (a literal CR, not a Windows line ending)', () => {
+    const patch = parsePatch(
+      'Index: test\n'
+      + '===================================================================\n'
+      + '--- test\theader1\n'
+      + '+++ test\theader2\n'
+      + '@@ -2,0 +3,1 @@\n'
+      + '+line3\r\n'
+      + '\\ No newline at end of file\n'
+    );
+    expect(isWin(patch)).to.equal(false);
   });
 });
 

--- a/test/patch/line-endings.js
+++ b/test/patch/line-endings.js
@@ -148,7 +148,7 @@ describe('isWin', () => {
     expect(isWin(patch)).to.equal(true);
   });
 
-  it('should return false if the only line ending in a CR is a no-newline-at-EOF line (a literal CR, not a Windows line ending)', () => {
+  it('should return false if the only line to end with a CR is a no-newline-at-EOF line (making it a stray literal CR, not a Windows line ending)', () => {
     const patch = parsePatch(
       'Index: test\n'
       + '===================================================================\n'

--- a/test/patch/line-endings.js
+++ b/test/patch/line-endings.js
@@ -47,7 +47,7 @@ describe('unixToWin and winToUnix', function() {
     expect(formatPatch(winToUnix(patch))).to.equal(formatPatch(unixPatch));
   });
 
-  it('should not introduce \\r on the last line if there was no newline at EOF', () => {
+  it('unixToWin should not introduce \\r on the last line if there was no newline at EOF', () => {
     const patch = parsePatch(
       'Index: test\n'
       + '===================================================================\n'

--- a/test/patch/line-endings.js
+++ b/test/patch/line-endings.js
@@ -149,7 +149,7 @@ describe('isUnix', () => {
     expect(isUnix(patch)).to.equal(true);
   });
 
-  it('should still return true if only the last line in a file is missing a LF and there is a no newline at EOF indicator', () => {
+  it('should still return true if only the last line in a file has a CR and there is a no newline at EOF indicator', () => {
     const patch = parsePatch(
       'Index: test\n'
       + '===================================================================\n'


### PR DESCRIPTION
## Bug

`applyPatch` corrupts output when a Unix source is patched with a patch whose final line's content ends in a literal carriage return and has no trailing newline. The `\r` is silently dropped.

```js
import { structuredPatch, applyPatch } from 'diff';
const oldFile = 'line1\nline2\n';
const newFile = 'line1\nline2\nline3\r';
const patch = structuredPatch('f', 'f', oldFile, newFile, undefined, undefined, {context: 0});
applyPatch(oldFile, patch); // => 'line1\nline2\nline3'  (the '\r' is lost)
```

I found this by fuzzing random source/target pairs through `structuredPatch` -> `applyPatch`; 80 of 200k pairs failed to round-trip, all of this shape.

## Cause

`isWin` and `winToUnix` treat any patch line ending in `\r` as a Windows CRLF line ending. But a line ending in `\r` that is immediately followed by a `\ No newline at end of file` marker is not a CRLF ending (Windows endings are `\r\n`) - it's a literal carriage return in the final line's content. A genuine Windows no-newline-at-EOF line never ends in `\r`.

So `isWin` misclassifies such a patch as Windows, and when `applyPatch` (with `autoConvertLineEndings` on) converts it to match the Unix source, `winToUnix` strips the `\r`.

`unixToWin` already guards this exact case (`hunk.lines[i + 1]?.startsWith('\\')`), so it won't add a `\r` to a no-newline final line. This change adds the symmetric guard to `isWin` and `winToUnix`.

## Fix

Ignore a trailing `\r` that sits immediately before a `\ No newline at end of file` marker when deciding whether a patch is Windows / when stripping CRs.

Added tests: a `winToUnix` unit test, an `isWin` unit test, and an `applyPatch` round-trip regression test. Full suite passes with 100% coverage.
